### PR TITLE
Initialize rsa_keygen in RSA_METHOD for openssl < 1.1.0

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -385,7 +385,8 @@ static RSA_METHOD ibmca_rsa = {
 	0,                       /* flags */
 	NULL,                    /* app_data */
 	NULL,                    /* rsa_sign */
-	NULL                     /* rsa_verify */
+	NULL,                    /* rsa_verify */
+	NULL                     /* rsa_keygen */
 };
 #else
 static RSA_METHOD *ibmca_rsa = NULL;


### PR DESCRIPTION
Setting as NULL the rsa_keygen field of RSA_METHOD structure when using
openssl < 1.1.0. Setting as NULL, the builtin RSA key generation will
be used.

This patch fixes GitHub issue #2

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>