### PR TITLE
Fix engine initialization to set funtion pointers only once.

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -1624,10 +1624,11 @@ static int ibmca_init(ENGINE * e)
 {
 	static int init = 0;
 
-	if (ibmca_dso != NULL && init >= 2) {
-		IBMCAerr(IBMCA_F_IBMCA_INIT, IBMCA_R_ALREADY_LOADED);
-		goto err;
+	if (init > 0) {
+		/* Engine already loaded, so exiting if called more than once.*/
+		return 1;
 	}
+
 	/* Attempt to load libica.so. Needs to be
 	 * changed unfortunately because the Ibmca drivers don't have
 	 * standard library names that can be platform-translated well. */


### PR DESCRIPTION
The engine initialization, ibmca_init() function, can be called more than
once causing the code to jump to a exit label where all internal function
pointers are set to NULL, which can cause a SIGSEGV.

This patch guarantees that the internal pointers will be set only once, by
exiting the ibmca_init() if already executed.

This patch fixes Ubuntu's LP#1443455

Signed-off-by: Harald Freudenberger <freude@linux.vnet.ibm.com>
Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>