### PR TITLE
Setting 'foreign' strictness for automake.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([openssl-ibmca], [1.3.1], [opencryptoki-users@lists.sf.net])
 AC_CONFIG_SRCDIR([src/e_ibmca.c]) # sanity check
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 # Cmdline arguments.
 AC_ARG_ENABLE([debug],


### PR DESCRIPTION
Setting 'foreign' strictness for automake stops silly things like
'not having a NEWS file' being a fatal error.

https://www.gnu.org/software/automake/manual/html_node/Strictness.html

Fixes #13

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>