### PR TITLE
Add compat macro for OpenSSL 1.0.1e-fips.

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -102,6 +102,10 @@
  #define EVP_CTRL_GCM_GET_TAG			EVP_CTRL_AEAD_GET_TAG
 #endif
 
+#ifndef EVP_AEAD_TLS1_AAD_LEN
+ #define EVP_AEAD_TLS1_AAD_LEN			13
+#endif
+
 typedef struct ibmca_des_context {
 	unsigned char key[sizeof(ica_des_key_triple_t)];
 } ICA_DES_CTX;


### PR DESCRIPTION
ibmca did not built with openssl 1.0.1e-fips on rhel 7.3. reintroduce the missing define.

Signed-off-by: Patrick Steuer <patrick.steuer@de.ibm.com>