### PR TITLE
Remove AC_FUNC_MALLOC from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,7 @@ AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_CHECK_FUNCS([gethostbyaddr gethostbyname memset strcasecmp strncasecmp strstr])
+AC_CHECK_FUNCS([gethostbyaddr gethostbyname memset strcasecmp strncasecmp strstr malloc])
 AC_CHECK_DECLS([ICA_FLAG_DHW,ica_get_functionlist,ica_open_adapter,DES_ECB], [],
 		AC_MSG_ERROR([*** libica >= 2.4.0 and libica-devel >= 2.4.0 are required ***]),
 		[#include <ica_api.h>])


### PR DESCRIPTION
Removed AC_FUNC_MALLOC from configure.ac, to make sure we are using
malloc() instead of rpl_malloc().

For more information search for AC_FUNC_MALLOC in
https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/Particular-Functions.html

Fixes #12

Siggned-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>