### PR TITLE
switch to ibmca.so filename to allow a standalone use

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
-lib_LTLIBRARIES=libibmca.la
+lib_LTLIBRARIES=ibmca.la
 
-libibmca_la_SOURCES=e_ibmca.c e_ibmca_err.c
-libibmca_la_LIBADD=-ldl
-libibmca_la_LDFLAGS=-module -version-info 0:2:0 -shared -no-undefined -avoid-version
+ibmca_la_SOURCES=e_ibmca.c e_ibmca_err.c
+ibmca_la_LIBADD=-ldl
+ibmca_la_LDFLAGS=-module -version-info 0:2:0 -shared -no-undefined -avoid-version
 
-dist_libibmca_la_SOURCES=e_ibmca_err.h e_os.h cryptlib.h
+dist_ibmca_la_SOURCES=e_ibmca_err.h e_os.h cryptlib.h
 EXTRA_DIST = openssl.cnf.sample
 
 ACLOCAL_AMFLAGS = -I m4

--- a/src/openssl.cnf.sample
+++ b/src/openssl.cnf.sample
@@ -23,7 +23,7 @@ ibmca = ibmca_section
 # The openssl engine path for libibmca.so.
 # Set the dynamic_path to where the libibmca.so engine
 # resides on the system.
-dynamic_path = /usr/local/lib/libibmca.so
+dynamic_path = /usr/local/lib/ibmca.so
 engine_id = ibmca
 init = 1
 


### PR DESCRIPTION
When the filename and engine name are the same (omitting the .so suffix), then it's possible to use the engine without configuration in openssl.conf (eg. "openssl speed -engine ibmca" works).