### PR TITLE
Update Makefile as some header files were removed

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ ibmca_la_SOURCES=e_ibmca.c e_ibmca_err.c
 ibmca_la_LIBADD=-ldl
 ibmca_la_LDFLAGS=-module -version-info 0:2:0 -shared -no-undefined -avoid-version
 
-dist_ibmca_la_SOURCES=e_ibmca_err.h e_os.h cryptlib.h
+dist_ibmca_la_SOURCES=e_ibmca_err.h 
 EXTRA_DIST = openssl.cnf.sample
 
 ACLOCAL_AMFLAGS = -I m4


### PR DESCRIPTION
Back in commit 5061482 we removed some old OpenSSL header files that
were not needed anymore. Ended up forgetting to update the Makefile.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>