### PR TITLE
Update m4s macro, documentation, spec file and test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ $ sudo make install
 ```
 
 This will configure, build and install the package in a default location,
-which is `/usr/local/lib`. It means that the libibmca.so will be installed in
-`/usr/local/lib/libibmca.so` by default. If you want to install it anywhere
+which is `/usr/local/lib`. It means that the ibmca.so will be installed in
+`/usr/local/lib/ibmca.so` by default. If you want to install it anywhere
 else, run "configure" passing the new location via prefix argument, for
 example:
 
@@ -48,8 +48,8 @@ in the host by the OpenSSL package. **WARNING:** you may want to save the
 original `openssl.cnf` file before changing it.
 
 In `openssl.cnf.sample`, the *dynamic_path* variable is set to the default
-location, which is `/usr/local/lib/libibmca.so` by default. However, if the
-libibmca.so library has been installed anywhere else, then update the
+location, which is `/usr/local/lib/ibmca.so` by default. However, if the
+ibmca.so library has been installed anywhere else, then update the
 *dynamic_path* variable.
 
 Locate where the `openssl.cnf` file has been installed in the host and append

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ fi
 # Checks for programs.
 AC_DISABLE_STATIC
 AC_PROG_CC
-AC_PROG_LIBTOOL
+LT_INIT
 
 # Checks for libraries.
 AC_CHECK_LIB([crypto], [RAND_add], [], AC_MSG_ERROR([*** openssl >= 0.9.8 is required ***]))

--- a/src/doc/ibmca.man
+++ b/src/doc/ibmca.man
@@ -24,7 +24,7 @@ discover control commands.
 Options for the IBMCA section in openssl.cnf:
 .PP
 dynamic_path =
-.I /path/to/libibmca.so
+.I /path/to/ibmca.so
 .RS
 Set the path to the IBMCA shared object file allowing OpenSSL to find the file.
 .RE

--- a/src/openssl.cnf.sample
+++ b/src/openssl.cnf.sample
@@ -20,8 +20,8 @@ ibmca = ibmca_section
 
 [ibmca_section]
 
-# The openssl engine path for libibmca.so.
-# Set the dynamic_path to where the libibmca.so engine
+# The openssl engine path for ibmca.so.
+# Set the dynamic_path to where the ibmca.so engine
 # resides on the system.
 dynamic_path = /usr/local/lib/ibmca.so
 engine_id = ibmca

--- a/src/test/ibmca_mechaList_test.c
+++ b/src/test/ibmca_mechaList_test.c
@@ -38,7 +38,7 @@ typedef struct{
 } id_map;
 
 #define AP_PATH  "/sys/devices/ap"
-#define IBMCA_PATH "/usr/lib64/openssl/engines/libibmca.so"
+#define IBMCA_PATH "/usr/lib64/openssl/engines/ibmca.so"
 
 
 id_map ica_to_ssl_map[] = {


### PR DESCRIPTION
Updating documentation, spec file and test code to the new lib name.
Also switching m4s macro that was deprecated to newest one.