### PR TITLE
Minor code changes and improvements.

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -42,6 +42,18 @@
  #define OLDER_OPENSSL
 #endif
 
+/*
+ * Here is a DEBUG_PRINTF makro which expands to nothing
+ * at production level and is active only when the
+ * ibmca build is configured with --enable-debug
+ */
+#ifdef DEBUG
+ #define DEBUG_PRINTF(...) printf(__VA_ARGS__)
+#else
+ #define DEBUG_PRINTF(...) do{} while(0)
+#endif
+
+
 #include <ica_api.h>
 #include "e_ibmca_err.h"
 
@@ -1582,6 +1594,8 @@ static int ibmca_init(ENGINE * e)
 		return 1;
 	init++;
 
+	DEBUG_PRINTF(">%s\n", __func__);
+
 	/* Attempt to load libica.so. Needs to be
 	 * changed unfortunately because the Ibmca drivers don't have
 	 * standard library names that can be platform-translated well. */
@@ -1594,6 +1608,7 @@ static int ibmca_init(ENGINE * e)
 
 	ibmca_dso = dlopen(LIBICA_SHARED_LIB, RTLD_NOW);
 	if (ibmca_dso == NULL) {
+		DEBUG_PRINTF("%s: dlopen(%s) failed\n", __func__, LIBICA_SHARED_LIB);
 		IBMCAerr(IBMCA_F_IBMCA_INIT, IBMCA_R_DSO_FAILURE);
 		goto err;
 	}
@@ -1626,6 +1641,7 @@ static int ibmca_init(ENGINE * e)
 #endif
 	   ) {
 		IBMCAerr(IBMCA_F_IBMCA_INIT, IBMCA_R_DSO_FAILURE);
+		DEBUG_PRINTF("%s: function bind failed\n", __func__);
 		goto err;
 	}
 
@@ -1641,6 +1657,7 @@ static int ibmca_init(ENGINE * e)
 		goto err;
 	}
 
+	DEBUG_PRINTF("<%s success\n", __func__);
 	return 1;
 err:
 	if (ibmca_dso) {

--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -1580,6 +1580,7 @@ static int ibmca_init(ENGINE * e)
 
 	if (init)	/* Engine already loaded. */
 		return 1;
+	init++;
 
 	/* Attempt to load libica.so. Needs to be
 	 * changed unfortunately because the Ibmca drivers don't have
@@ -1640,7 +1641,6 @@ static int ibmca_init(ENGINE * e)
 		goto err;
 	}
 
-	init = 1;
 	return 1;
 err:
 	if (ibmca_dso) {

--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -1446,6 +1446,7 @@ void *ibmca_dso = NULL;
 /* These are the function pointers that are (un)set when the library has
  * successfully (un)loaded. */
 
+typedef void	     (*ica_set_fallback_mode_t)(int);
 typedef unsigned int (*ica_open_adapter_t)(ica_adapter_handle_t *);
 typedef unsigned int (*ica_close_adapter_t)(ica_adapter_handle_t);
 typedef unsigned int (*ica_rsa_mod_expo_t)(ica_adapter_handle_t, unsigned char *,
@@ -1527,6 +1528,7 @@ typedef unsigned int (*ica_aes_gcm_last_t)(unsigned char *icb,
 					   unsigned int direction);
 
 /* entry points into libica, filled out at DSO load time */
+ica_set_fallback_mode_t		p_ica_set_fallback_mode;
 ica_open_adapter_t		p_ica_open_adapter;
 ica_close_adapter_t		p_ica_close_adapter;
 ica_rsa_mod_expo_t		p_ica_rsa_mod_expo;
@@ -1625,6 +1627,10 @@ static int ibmca_init(ENGINE * e)
 		IBMCAerr(IBMCA_F_IBMCA_INIT, IBMCA_R_DSO_FAILURE);
 		goto err;
 	}
+
+	// disable fallbacks on Libica
+	if (BIND(ibmca_dso, ica_set_fallback_mode))
+		p_ica_set_fallback_mode(0);
 
         if(!set_supported_meths(e))
                 goto err;


### PR DESCRIPTION
- Make Ibmca use the fallback API at Libica if available to switch off the fallbacks.
- Ibmca init function was called twice because of race condition at the local static init variable.
- Provide DEBUG_PRINTF macro for very simple and easy debugging possibility.