### PR TITLE
Fix dlclose logic

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -1745,7 +1745,7 @@ static int ibmca_finish(ENGINE * e)
 		return 0;
 	}
 	release_context(ibmca_handle);
-	if (!dlclose(ibmca_dso)) {
+	if (dlclose(ibmca_dso)) {
 		IBMCAerr(IBMCA_F_IBMCA_FINISH, IBMCA_R_DSO_FAILURE);
 		return 0;
 	}


### PR DESCRIPTION
dlclose returns 0 on success and the current code was treating success
as an error.
This fixes #37.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>