### PR TITLE
omit version from filename

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ ibmca_la_SOURCES=e_ibmca.c \
 
 ibmca_la_LIBADD=-ldl
 ibmca_la_LDFLAGS=-module -version-info ${VERSION} -shared -no-undefined \
-				 -Wl,--version-script=${srcdir}/../ibmca.map
+		  -avoid-version -Wl,--version-script=${srcdir}/../ibmca.map
 
 dist_ibmca_la_SOURCES=ibmca.h e_ibmca_err.h
 EXTRA_DIST = openssl.cnf.sample


### PR DESCRIPTION
The ibmca.so file is a dlopen()-ed module, so having the version info
in the filename is superfluous.