### PR TITLE
Fix doing rsa-me, altough rsa-crt would be possible

### DIFF
--- a/src/ibmca_rsa.c
+++ b/src/ibmca_rsa.c
@@ -309,7 +309,7 @@ static int ibmca_rsa_mod_exp(BIGNUM * r0, const BIGNUM * I, RSA * rsa,
     RSA_get0_key(rsa, &n, NULL, &d);
     RSA_get0_factors(rsa, &p, &q);
     RSA_get0_crt_params(rsa, &dmp1, &dmq1, &iqmp);
-    if (!p || !q || !dmp1 || !dmq1 || iqmp) {
+    if (!p || !q || !dmp1 || !dmq1 || !iqmp) {
         if (!d || !n) {
             IBMCAerr(IBMCA_F_IBMCA_RSA_MOD_EXP, IBMCA_R_MISSING_KEY_COMPONENTS);
             goto err;


### PR DESCRIPTION
rsa-crt is preferred to rsa-me when possible for performance reason.
This bug was introduced with commit dc8465b (ibmca >= 1.3.1) for
openssl >= 1.1.0. Commit ed496f6 (ibmca >= 2.0.0) introduced the bug
also for openssl versions < 1.1.0.

Signed-off-by: Patrick Steuer <patrick.steuer@de.ibm.com>