### PR TITLE
Set *_FLAG_FIPS_METHOD flags

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -365,9 +365,11 @@ inline static int set_EC_prop(ENGINE *e)
     ECDSA_METHOD_set_name(ibmca_ecdsa, "Ibmca ECDSA method");
     ECDSA_METHOD_set_sign(ibmca_ecdsa, ibmca_older_ecdsa_do_sign);
     ECDSA_METHOD_set_verify(ibmca_ecdsa, ibmca_older_ecdsa_do_verify);
+    ECDSA_METHOD_set_flags(ibmca_ecdsa, ECDSA_FLAG_FIPS_METHOD);
 
     ECDH_METHOD_set_name(ibmca_ecdh, "Ibmca ECDH method");
     ECDH_METHOD_set_compute_key(ibmca_ecdh, ibmca_older_ecdh_compute_key);
+    ECDH_METHOD_set_flags(ibmca_ecdh, ECDH_FLAG_FIPS_METHOD);
 
     if (!ENGINE_set_ECDH(e, ibmca_ecdh))
         return 0;

--- a/src/ibmca_cipher.c
+++ b/src/ibmca_cipher.c
@@ -231,22 +231,22 @@ void ibmca_tdes_##mode##_destroy(void)                                  \
 #endif
 
 DECLARE_TDES_EVP(ecb, sizeof(ica_des_vector_t), sizeof(ica_des_key_triple_t),
-                 sizeof(ica_des_vector_t), EVP_CIPH_ECB_MODE,
+                 sizeof(ica_des_vector_t), EVP_CIPH_ECB_MODE | EVP_CIPH_FLAG_FIPS,
                  sizeof(struct ibmca_des_context), ibmca_init_key,
                  ibmca_3des_cipher, ibmca_cipher_cleanup,
                  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv)
 DECLARE_TDES_EVP(cbc, sizeof(ica_des_vector_t), sizeof(ica_des_key_triple_t),
-                 sizeof(ica_des_vector_t), EVP_CIPH_CBC_MODE,
+                 sizeof(ica_des_vector_t), EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_FIPS,
                  sizeof(struct ibmca_des_context), ibmca_init_key,
                  ibmca_3des_cipher, ibmca_cipher_cleanup,
                  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv)
 DECLARE_TDES_EVP(ofb, 1, sizeof(ica_des_key_triple_t),
-                 sizeof(ica_des_vector_t), EVP_CIPH_OFB_MODE,
+                 sizeof(ica_des_vector_t), EVP_CIPH_OFB_MODE | EVP_CIPH_FLAG_FIPS,
                  sizeof(struct ibmca_des_context), ibmca_init_key,
                  ibmca_3des_cipher, ibmca_cipher_cleanup,
                  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv)
 DECLARE_TDES_EVP(cfb, 1, sizeof(ica_des_key_triple_t),
-                 sizeof(ica_des_vector_t), EVP_CIPH_CFB_MODE,
+                 sizeof(ica_des_vector_t), EVP_CIPH_CFB_MODE | EVP_CIPH_FLAG_FIPS,
                  sizeof(struct ibmca_des_context), ibmca_init_key,
                  ibmca_3des_cipher, ibmca_cipher_cleanup,
                  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv)
@@ -716,21 +716,21 @@ void ibmca_aes_##kbits##_##mode##_destroy(void)                         \
 
 DECLARE_AES_EVP(128, ecb, sizeof(ica_aes_vector_t),
                 sizeof(ica_aes_key_len_128_t), sizeof(ica_aes_vector_t),
-                EVP_CIPH_ECB_MODE, sizeof(ICA_AES_128_CTX),
+                EVP_CIPH_ECB_MODE | EVP_CIPH_FLAG_FIPS, sizeof(ICA_AES_128_CTX),
                 ibmca_init_key, ibmca_aes_128_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(128, cbc, sizeof(ica_aes_vector_t),
                 sizeof(ica_aes_key_len_128_t), sizeof(ica_aes_vector_t),
-                EVP_CIPH_CBC_MODE, sizeof(ICA_AES_128_CTX),
+                EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_FIPS, sizeof(ICA_AES_128_CTX),
                 ibmca_init_key, ibmca_aes_128_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(128, ofb, 1, sizeof(ica_aes_key_len_128_t),
-                sizeof(ica_aes_vector_t), EVP_CIPH_OFB_MODE,
+                sizeof(ica_aes_vector_t), EVP_CIPH_OFB_MODE | EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_128_CTX), ibmca_init_key,
                 ibmca_aes_128_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(128, cfb, 1, sizeof(ica_aes_key_len_128_t),
-                sizeof(ica_aes_vector_t), EVP_CIPH_CFB_MODE,
+                sizeof(ica_aes_vector_t), EVP_CIPH_CFB_MODE | EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_128_CTX), ibmca_init_key,
                 ibmca_aes_128_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
@@ -740,7 +740,8 @@ DECLARE_AES_EVP(128, gcm, 1, sizeof(ica_aes_key_len_128_t),
                 EVP_CIPH_GCM_MODE | EVP_CIPH_FLAG_DEFAULT_ASN1
                 | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER
                 | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT
-                | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER,
+                | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER
+		| EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_GCM_CTX),
                 ibmca_aes_gcm_init_key, ibmca_aes_gcm_cipher, NULL, NULL,
                 NULL, ibmca_aes_gcm_ctrl)
@@ -748,21 +749,21 @@ DECLARE_AES_EVP(128, gcm, 1, sizeof(ica_aes_key_len_128_t),
 
 DECLARE_AES_EVP(192, ecb, sizeof(ica_aes_vector_t),
                 sizeof(ica_aes_key_len_192_t), sizeof(ica_aes_vector_t),
-                EVP_CIPH_ECB_MODE, sizeof(ICA_AES_192_CTX),
+                EVP_CIPH_ECB_MODE | EVP_CIPH_FLAG_FIPS, sizeof(ICA_AES_192_CTX),
                 ibmca_init_key, ibmca_aes_192_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(192, cbc, sizeof(ica_aes_vector_t),
                 sizeof(ica_aes_key_len_192_t), sizeof(ica_aes_vector_t),
-                EVP_CIPH_CBC_MODE, sizeof(ICA_AES_192_CTX),
+                EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_FIPS, sizeof(ICA_AES_192_CTX),
                 ibmca_init_key, ibmca_aes_192_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(192, ofb, 1, sizeof(ica_aes_key_len_192_t),
-                sizeof(ica_aes_vector_t), EVP_CIPH_OFB_MODE,
+                sizeof(ica_aes_vector_t), EVP_CIPH_OFB_MODE | EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_192_CTX), ibmca_init_key,
                 ibmca_aes_192_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(192, cfb, 1, sizeof(ica_aes_key_len_192_t),
-                sizeof(ica_aes_vector_t), EVP_CIPH_CFB_MODE,
+                sizeof(ica_aes_vector_t), EVP_CIPH_CFB_MODE | EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_192_CTX), ibmca_init_key,
                 ibmca_aes_192_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
@@ -772,7 +773,8 @@ DECLARE_AES_EVP(192, gcm, 1, sizeof(ica_aes_key_len_192_t),
                 EVP_CIPH_GCM_MODE | EVP_CIPH_FLAG_DEFAULT_ASN1
                 | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER
                 | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT
-                | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER,
+                | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER
+		| EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_GCM_CTX),
                 ibmca_aes_gcm_init_key, ibmca_aes_gcm_cipher, NULL, NULL,
                 NULL, ibmca_aes_gcm_ctrl)
@@ -780,21 +782,21 @@ DECLARE_AES_EVP(192, gcm, 1, sizeof(ica_aes_key_len_192_t),
 
 DECLARE_AES_EVP(256, ecb, sizeof(ica_aes_vector_t),
                 sizeof(ica_aes_key_len_256_t), sizeof(ica_aes_vector_t),
-                EVP_CIPH_ECB_MODE, sizeof(ICA_AES_256_CTX),
+                EVP_CIPH_ECB_MODE | EVP_CIPH_FLAG_FIPS, sizeof(ICA_AES_256_CTX),
                 ibmca_init_key, ibmca_aes_256_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(256, cbc, sizeof(ica_aes_vector_t),
                 sizeof(ica_aes_key_len_256_t), sizeof(ica_aes_vector_t),
-                EVP_CIPH_CBC_MODE, sizeof(ICA_AES_256_CTX),
+                EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_FIPS, sizeof(ICA_AES_256_CTX),
                 ibmca_init_key, ibmca_aes_256_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(256, ofb, 1, sizeof(ica_aes_key_len_256_t),
-                sizeof(ica_aes_vector_t), EVP_CIPH_OFB_MODE,
+                sizeof(ica_aes_vector_t), EVP_CIPH_OFB_MODE | EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_256_CTX), ibmca_init_key,
                 ibmca_aes_256_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 DECLARE_AES_EVP(256, cfb, 1, sizeof(ica_aes_key_len_256_t),
-                sizeof(ica_aes_vector_t), EVP_CIPH_CFB_MODE,
+                sizeof(ica_aes_vector_t), EVP_CIPH_CFB_MODE | EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_256_CTX), ibmca_init_key,
                 ibmca_aes_256_cipher, ibmca_cipher_cleanup,
                 EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
@@ -804,7 +806,8 @@ DECLARE_AES_EVP(256, gcm, 1, sizeof(ica_aes_key_len_256_t),
                 EVP_CIPH_GCM_MODE | EVP_CIPH_FLAG_DEFAULT_ASN1
                 | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER
                 | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT
-                | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER,
+                | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER
+		| EVP_CIPH_FLAG_FIPS,
                 sizeof(ICA_AES_GCM_CTX),
                 ibmca_aes_gcm_init_key, ibmca_aes_gcm_cipher, NULL, NULL,
                 NULL, ibmca_aes_gcm_ctrl)

--- a/src/ibmca_dh.c
+++ b/src/ibmca_dh.c
@@ -37,7 +37,7 @@ static DH_METHOD dh_m = {
     ibmca_mod_exp_dh,           /* bn_mod_exp */
     NULL,                       /* init */
     NULL,                       /* finish */
-    0,                          /* flags */
+    DH_FLAG_FIPS_METHOD,        /* flags */
     NULL                        /* app_data */
 };
 
@@ -65,7 +65,8 @@ DH_METHOD *ibmca_dh(void)
         || (meth1 = DH_OpenSSL()) == NULL
         || !DH_meth_set_generate_key(method, DH_meth_get_generate_key(meth1))
         || !DH_meth_set_compute_key(method, DH_meth_get_compute_key(meth1))
-        || !DH_meth_set_bn_mod_exp(method, ibmca_mod_exp_dh)) {
+        || !DH_meth_set_bn_mod_exp(method, ibmca_mod_exp_dh)
+        || !DH_meth_set_flags(method, DH_FLAG_FIPS_METHOD)) {
         DH_meth_free(method);
         method = NULL;
         meth1 = NULL;

--- a/src/ibmca_dsa.c
+++ b/src/ibmca_dsa.c
@@ -84,7 +84,7 @@ static DSA_METHOD dsa_m = {
     ibmca_mod_exp_dsa,          /* bn_mod_exp */
     NULL,                       /* init */
     NULL,                       /* finish */
-    0,                          /* flags */
+    DSA_FLAG_FIPS_METHOD,       /* flags */
     NULL                        /* app_data */
 };
 
@@ -115,7 +115,8 @@ DSA_METHOD *ibmca_dsa(void)
         || !DSA_meth_set_sign_setup(method, DSA_meth_get_sign_setup(meth1))
         || !DSA_meth_set_verify(method, DSA_meth_get_verify(meth1))
         || !DSA_meth_set_mod_exp(method, ibmca_dsa_mod_exp)
-        || !DSA_meth_set_bn_mod_exp(method, ibmca_mod_exp_dsa)) {
+        || !DSA_meth_set_bn_mod_exp(method, ibmca_mod_exp_dsa)
+        || !DSA_meth_set_flags(method, DSA_FLAG_FIPS_METHOD)) {
         DSA_meth_free(method);
         method = NULL;
         meth1 = NULL;

--- a/src/ibmca_rsa.c
+++ b/src/ibmca_rsa.c
@@ -342,7 +342,7 @@ static RSA_METHOD rsa_m = {
     ibmca_mod_exp_mont,         /* bn_mod_exp */
     ibmca_rsa_init,             /* init */
     NULL,                       /* finish */
-    0,                          /* flags */
+    RSA_FLAG_FIPS_METHOD,       /* flags */
     NULL,                       /* app_data */
     NULL,                       /* rsa_sign */
     NULL,                       /* rsa_verify */
@@ -386,7 +386,8 @@ RSA_METHOD *ibmca_rsa(void)
         || !RSA_meth_set_priv_dec(method, RSA_meth_get_priv_dec(meth1))
         || !RSA_meth_set_mod_exp(method, ibmca_rsa_mod_exp)
         || !RSA_meth_set_bn_mod_exp(method, ibmca_mod_exp_mont)
-        || !RSA_meth_set_init(method, ibmca_rsa_init)) {
+        || !RSA_meth_set_init(method, ibmca_rsa_init)
+        || !RSA_meth_set_flags(method, RSA_FLAG_FIPS_METHOD)) {
         RSA_meth_free(method);
         method = NULL;
         meth1 = NULL;


### PR DESCRIPTION
Enable engine to be used with openssl fips builds.

Signed-off-by: Patrick Steuer <patrick.steuer@de.ibm.com>