### PR TITLE
ibmca: rework on error string init and exit

### DIFF
--- a/src/e_ibmca.c
+++ b/src/e_ibmca.c
@@ -635,6 +635,7 @@ static void ibmca_constructor(void)
 
     if (init)
         return;
+    init = 1;
 
     ERR_load_IBMCA_strings();
 
@@ -753,8 +754,6 @@ err:
 __attribute__((destructor))
 static void ibmca_destructor(void)
 {
-    ERR_unload_IBMCA_strings();
-
     if (ibmca_dso == NULL) {
         IBMCAerr(IBMCA_F_IBMCA_FINISH, IBMCA_R_NOT_LOADED);
         return;

--- a/src/e_ibmca_err.c
+++ b/src/e_ibmca_err.c
@@ -92,42 +92,26 @@ static ERR_STRING_DATA IBMCA_lib_name[] = {
 };
 #endif
 
-
 static int IBMCA_lib_error_code = 0;
-static int IBMCA_error_init = 1;
+static int IBMCA_error_init = 0;
 
 void ERR_load_IBMCA_strings(void)
 {
-    if (IBMCA_lib_error_code == 0)
-        IBMCA_lib_error_code = ERR_get_next_error_library();
+    if (IBMCA_error_init)
+        return;
+    IBMCA_error_init = 1;
 
-    if (IBMCA_error_init) {
-        IBMCA_error_init = 0;
+    IBMCA_lib_error_code = ERR_get_next_error_library();
+
 #ifndef OPENSSL_NO_ERR
-        ERR_load_strings(IBMCA_lib_error_code, IBMCA_str_functs);
-        ERR_load_strings(IBMCA_lib_error_code, IBMCA_str_reasons);
+    ERR_load_strings(IBMCA_lib_error_code, IBMCA_str_functs);
+    ERR_load_strings(IBMCA_lib_error_code, IBMCA_str_reasons);
 #endif
 
 #ifdef IBMCA_LIB_NAME
-        IBMCA_lib_name->error = ERR_PACK(IBMCA_lib_error_code, 0, 0);
-        ERR_load_strings(0, IBMCA_lib_name);
+    IBMCA_lib_name->error = ERR_PACK(lib_error_code, 0, 0);
+    ERR_load_strings(0, IBMCA_lib_name);
 #endif
-    }
-}
-
-void ERR_unload_IBMCA_strings(void)
-{
-    if (IBMCA_error_init == 0) {
-#ifndef OPENSSL_NO_ERR
-        ERR_unload_strings(IBMCA_lib_error_code, IBMCA_str_functs);
-        ERR_unload_strings(IBMCA_lib_error_code, IBMCA_str_reasons);
-#endif
-
-#ifdef IBMCA_LIB_NAME
-        ERR_unload_strings(0, IBMCA_lib_name);
-#endif
-        IBMCA_error_init = 1;
-    }
 }
 
 void ERR_IBMCA_error(int function, int reason, char *file, int line)

--- a/src/e_ibmca_err.h
+++ b/src/e_ibmca_err.h
@@ -20,7 +20,6 @@
 
 /* BEGIN ERROR CODES */
 void ERR_load_IBMCA_strings(void);
-void ERR_unload_IBMCA_strings(void);
 void ERR_IBMCA_error(int function, int reason, char *file, int line);
 #define IBMCAerr(f,r) ERR_IBMCA_error((f),(r),__FILE__,__LINE__)
 


### PR DESCRIPTION
A crash on Ubuntu 19.04pre showed that there may be a problem
in the error string load/free functions. So here is a slight
rework which does:
- Simple rework of the ERR_load_IBMCA_strings().
  Just make the code path a little clearer.
- Remove the ERR_unload_IBMCA_strings() function.
  Not really needed, freed on application exit anyway.
- Set the init variable in the constructor of the
  ibmca shared lib to 1 to avoid multiple initializations.

The fix has been verified and fixes the issue seen with Ubuntu 19.04.