### PR TITLE
Enable copr builds and add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,14 @@
+downstream_package_name: openssl-ibmca
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
+specfile_path: openssl-ibmca.spec
+synced_files:
+- openssl-ibmca.spec
+- .packit.yaml
+upstream_package_name: openssl-ibmca


### PR DESCRIPTION

Let us introduce [packit service](https://packit.dev) to you - the automation to integrate upstream open source projects into Fedora operating system.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

But there is more. By using packit, you can for example enable adding new releases into Fedora Rawhide.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact @packit-service
