### PR TITLE
Skip eckey test if needed.

### DIFF
--- a/test/eckey.c
+++ b/test/eckey.c
@@ -44,6 +44,10 @@ int check_eckey(int nid, const char *name)
         fprintf(stderr, "ibmca engine not loaded\n");
         goto out;
     }
+    if (ENGINE_get_EC(engine) == NULL) {
+        fprintf(stderr, "ibmca does not support EC_KEY.  Skipping...\n");
+        exit(77);
+    }
     eckey = EC_KEY_new_by_curve_name(nid);
     if (eckey == NULL) {
         /* curve not supported => test passed */


### PR DESCRIPTION
Without crypto cards on a machine < z14, ibmca might not register with the
EC_KEY subsystem of OpenSSL.  In these cases, the eckey test should be skipped
since it is doomed to fail.

Fixes #69.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>