### PR TITLE
use correct libica for ibmca_mechaList_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,11 @@ autom4te.cache
 *.la
 *.o
 *.tar.gz
+ibmca-engine-opensslconfig
+ibmca_mechaList_test
 Makefile
 Makefile.in
+Makefile.linux
 config.status
 config.log
 configure

--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,10 @@ AC_ARG_WITH([libica-version],
 
 if test "x$usecexonly" = xyes; then
 	defaultlib="libica-cex.so.$libicaversion"
+	ica="ica-cex"
 else
 	defaultlib="libica.so.$libicaversion"
+	ica="ica"
 fi
 # In cex-only mode, testing the ciphers does not make any sense since
 # they will fall back to OpenSSL without the engine.  So remove these
@@ -67,6 +69,7 @@ fi
 AM_CONDITIONAL([FULL_LIBICA], [test "x$usecexonly" != xyes])
 
 AC_DEFINE_UNQUOTED([LIBICA_SHARED_LIB],["$defaultlib"])
+AC_SUBST([ICA],["$ica"])
 
 AC_CHECK_PROG([openssl_var],[openssl],[yes],[no])
 if test "x$openssl_var" != xyes; then
@@ -76,6 +79,7 @@ fi
 AC_CONFIG_FILES([
 	Makefile
 	src/Makefile
+	src/test/Makefile.linux
 	test/Makefile
 	src/doc/Makefile])
 

--- a/src/test/Makefile.linux.in
+++ b/src/test/Makefile.linux.in
@@ -8,7 +8,7 @@ all: $(TARGETS)
 
 # Every target is created from a single .c file.
 %: %.c
-	gcc $(OPTS) -o $@ $^ -lica -lcrypto
+	gcc $(OPTS) -o $@ $^ -l@ICA@ -lcrypto
 
 clean:
 	rm -f $(TARGETS)


### PR DESCRIPTION
Generate the Makefile for ibmca_mechaList_test during the configure run,
so it links with the same libica variant as used by the ibmca.so module.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2059489