### PR TITLE
test/provider: Don't run RSA 16K test to reduce the test run time

### DIFF
--- a/test/provider/Makefile.am
+++ b/test/provider/Makefile.am
@@ -7,8 +7,8 @@ rsa512.pl	\
 rsa1k.pl	\
 rsa2k.pl	\
 rsa4k.pl	\
-rsa8k.pl	\
-rsa16k.pl
+rsa8k.pl
+#rsa16k.pl
 
 TESTS = \
 	rsakey		\


### PR DESCRIPTION
The RSA 16K test alone runs for about 30 minutes. Since the RSA 8K test already utilizes the fall-backs, testing RSA 16K does not add much of test coverage.