### PR TITLE
provider: Adapt keymgmt_match() implementations to OpenSSL

### DIFF
--- a/src/provider/dh_keymgmt.c
+++ b/src/provider/dh_keymgmt.c
@@ -1000,7 +1000,7 @@ static int ibmca_keymgmt_dh_match(const void *vkey1, const void *vkey2,
             }
         }
 
-        if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+        if (!checked && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
             if (key1->dh.priv != NULL || key2->dh.priv != NULL) {
                 ok = ok && (BN_cmp(key1->dh.priv, key2->dh.priv) == 0);
                 checked = 1;

--- a/src/provider/ec_keymgmt.c
+++ b/src/provider/ec_keymgmt.c
@@ -751,7 +751,7 @@ static int ibmca_keymgmt_ec_match(const void *vkey1, const void *vkey2,
     const struct ibmca_key *key2 = vkey2;
     BIGNUM *x1 = NULL, *y1 = NULL, *d1 = NULL;
     BIGNUM *x2 = NULL, *y2 = NULL, *d2 = NULL;
-    int ok = 1, rc1, rc2;
+    int ok = 1, rc1, rc2, checked = 0;
 
     if (key1 == NULL || key2 == NULL)
         return 0;
@@ -781,9 +781,10 @@ static int ibmca_keymgmt_ec_match(const void *vkey1, const void *vkey2,
 
         ok = ok && (rc1 == rc2 && (rc1 == -1 ||
                     (BN_cmp(x1, x2) == 0 && BN_cmp(y1, y2) == 0)));
+        checked = 1;
     }
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+    if (!checked && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
         rc1 = ibmca_keymgmt_ec_priv_key_as_bn(key1, &d1);
         if (rc1 == 0) {
             ok = 0;

--- a/src/provider/rsa_keymgmt.c
+++ b/src/provider/rsa_keymgmt.c
@@ -641,7 +641,7 @@ static int ibmca_keymgmt_rsa_match(const void *vkey1, const void *vkey2,
 {
     const struct ibmca_key *key1 = vkey1;
     const struct ibmca_key *key2 = vkey2;
-    int ok = 1;
+    int ok = 1, checked = 0;
 
     if (key1 == NULL || key2 == NULL)
         return 0;
@@ -652,7 +652,7 @@ static int ibmca_keymgmt_rsa_match(const void *vkey1, const void *vkey2,
     if (ibmca_keymgmt_match(key1, key2) == 0)
         return 0;
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
         ok = ok && (key1->rsa.public.key_length ==
                            key2->rsa.public.key_length &&
                     memcmp(key1->rsa.public.exponent,
@@ -661,8 +661,10 @@ static int ibmca_keymgmt_rsa_match(const void *vkey1, const void *vkey2,
                     memcmp(key1->rsa.public.modulus,
                            key2->rsa.public.modulus,
                            key1->rsa.public.key_length) == 0);
+        checked = 1;
+    }
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
+    if (!checked && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
         ok = ok && (key1->rsa.private.key_length ==
                            key2->rsa.private.key_length &&
                     CRYPTO_memcmp(key1->rsa.private.p,


### PR DESCRIPTION
OpenSSL commit [ee22a3741e3fc27c981e7f7e9bcb8d3342b0c65a ](https://github.com/openssl/openssl/commit/ee22a3741e3fc27c981e7f7e9bcb8d3342b0c65a) changed the OpenSSL provider's keymgmt_match() function to be not so strict with the selector bits in regards to matching different key parts.

Adapt the provider's match functions accordingly.
This means, that if the public key is selected to be matched, and the public key matches (together with any also selected parameters), then the private key is no longer checked, although it may also be selected to be matched. This is according to how the OpenSSL function EVP_PKEY_eq() is supposed to behave.

Signed-off-by: Ingo Franzki <ifranzki@linux.ibm.com>