### PR TITLE
tests: skip tests if libica does not support required algorithms

### DIFF
--- a/test/provider/Makefile.am
+++ b/test/provider/Makefile.am
@@ -20,13 +20,25 @@ TESTS = \
 check_PROGRAMS = rsakey eckey dhkey threadtest
 
 dhkey_SOURCES = dhkey.c
-dhkey_LDADD = -lcrypto
+if PROVIDER_FULL_LIBICA
+dhkey_LDADD = -lcrypto -lica
+else
+dhkey_LDADD = -lcrypto -lica-cex
+endif
 
 eckey_SOURCES = eckey.c
-eckey_LDADD = -lcrypto
+if PROVIDER_FULL_LIBICA
+eckey_LDADD = -lcrypto -lica
+else
+eckey_LDADD = -lcrypto -lica-cex
+endif
 
 rsakey_SOURCES = rsakey.c
-rsakey_LDADD = -lcrypto
+if PROVIDER_FULL_LIBICA
+rsakey_LDADD = -lcrypto -lica
+else
+rsakey_LDADD = -lcrypto -lica-cex
+endif
 
 threadtest_SOURCES = threadtest.c
 threadtest_LDADD = -lcrypto -lpthread

--- a/test/provider/dhkey.c
+++ b/test/provider/dhkey.c
@@ -27,6 +27,8 @@
 #include <openssl/core_names.h>
 #include <openssl/err.h>
 
+#include <ica_api.h>
+
 #define UNUSED(var)                             ((void)(var))
 
 void setup(void)
@@ -349,6 +351,56 @@ int check_dhkey(int nid, const char *name, const char *algo)
     return ret;
 }
 
+static const unsigned int required_ica_mechs[] = { RSA_ME };
+static const unsigned int required_ica_mechs_len =
+                        sizeof(required_ica_mechs) / sizeof(unsigned int);
+
+int check_libica()
+{
+    unsigned int mech_len, i, k, found = 0;
+    libica_func_list_element *mech_list = NULL;
+    int rc;
+
+    rc = ica_get_functionlist(NULL, &mech_len);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to get function list from libica!\n");
+        return 77;
+    }
+
+    mech_list = calloc(sizeof(libica_func_list_element), mech_len);
+    if (mech_list == NULL) {
+        fprintf(stderr, "Failed to allocate memory for function list!\n");
+        return 77;
+    }
+
+    rc = ica_get_functionlist(mech_list, &mech_len);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to get function list from libica!\n");
+        free(mech_list);
+        return 77;
+    }
+
+    for (i = 0; i < mech_len; i++) {
+        for (k = 0; k < required_ica_mechs_len; k++) {
+            if (mech_list[i].mech_mode_id == required_ica_mechs[k]) {
+                if (mech_list[i].flags &
+                    (ICA_FLAG_SW | ICA_FLAG_SHW | ICA_FLAG_DHW))
+                    found++;
+            }
+        }
+    }
+
+    free(mech_list);
+
+    if (found < required_ica_mechs_len) {
+        fprintf(stderr,
+               "Libica does not support the required algorithms, skipping.\n");
+        return 77;
+    }
+
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     static const struct testparams {
@@ -388,6 +440,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "Failed to set OPENSSL_MODULES environment variable!\n");
         return 77;
     }
+
+    ret = check_libica();
+    if (ret != 0)
+        return ret;
 
     setup();
     for (i = 0; i < (int)(sizeof(params) / sizeof(struct testparams)); ++i) {

--- a/test/provider/eckey.c
+++ b/test/provider/eckey.c
@@ -27,6 +27,8 @@
 #include <openssl/core_names.h>
 #include <openssl/err.h>
 
+#include <ica_api.h>
+
 #define UNUSED(var)                             ((void)(var))
 
 void setup(void)
@@ -781,6 +783,57 @@ int check_eckey(int nid, const char *name)
     return ret;
 }
 
+static const unsigned int required_ica_mechs[] = { EC_DH, EC_DSA_SIGN,
+                                                   EC_DSA_VERIFY, EC_KGEN, };
+static const unsigned int required_ica_mechs_len =
+                        sizeof(required_ica_mechs) / sizeof(unsigned int);
+
+int check_libica()
+{
+    unsigned int mech_len, i, k, found = 0;
+    libica_func_list_element *mech_list = NULL;
+    int rc;
+
+    rc = ica_get_functionlist(NULL, &mech_len);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to get function list from libica!\n");
+        return 77;
+    }
+
+    mech_list = calloc(sizeof(libica_func_list_element), mech_len);
+    if (mech_list == NULL) {
+        fprintf(stderr, "Failed to allocate memory for function list!\n");
+        return 77;
+    }
+
+    rc = ica_get_functionlist(mech_list, &mech_len);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to get function list from libica!\n");
+        free(mech_list);
+        return 77;
+    }
+
+    for (i = 0; i < mech_len; i++) {
+        for (k = 0; k < required_ica_mechs_len; k++) {
+            if (mech_list[i].mech_mode_id == required_ica_mechs[k]) {
+                if (mech_list[i].flags &
+                    (ICA_FLAG_SW | ICA_FLAG_SHW | ICA_FLAG_DHW))
+                    found++;
+            }
+        }
+    }
+
+    free(mech_list);
+
+    if (found < required_ica_mechs_len) {
+        fprintf(stderr,
+               "Libica does not support the required algorithms, skipping.\n");
+        return 77;
+    }
+
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     static const struct testparams {
@@ -821,6 +874,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "Failed to set OPENSSL_MODULES environment variable!\n");
         return 77;
     }
+
+    ret = check_libica();
+    if (ret != 0)
+        return ret;
 
     setup();
     for (i = 0; i < (int)(sizeof(params) / sizeof(struct testparams)); ++i) {


### PR DESCRIPTION
Before actually running the tests, check if libica supports the required algorithms. Skip the whole test if not.

This can happen when running the test on a system without appropriate crypto adapters. This would lead to the situation that the provider would not register itself for the required algorithms, and thus the OpenSSL default provider would be used. This would make the tests to fail, because it is not running with the IBMCA provider as expected by the test.

Fixes https://github.com/opencryptoki/openssl-ibmca/issues/84