### PR TITLE
Provider: Fix parallel test runs

### DIFF
--- a/test/provider/test.pm
+++ b/test/provider/test.pm
@@ -29,30 +29,30 @@ sub rsaencdec {
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsa$keylen.key`;
-    `$prov openssl rsa -in rsa$keylen.key -check -pubout -out rsa$keylen.pub`;
+    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsaencdec$keylen.key`;
+    `$prov openssl rsa -in rsaencdec$keylen.key -check -pubout -out rsaencdec$keylen.pub`;
     exit(99) if ($?);
 
     for my $i (1..$tests) {
         my $bytes = 1 + int(rand($max_file_size));
         # provider enc, no-provider dec
         `openssl rand $bytes > rsaencdec.${i}.${keylen}.data.in`;
-        `$prov openssl pkeyutl -encrypt -pubin -inkey rsa$keylen.pub -in rsaencdec.${i}.${keylen}.data.in -out rsaencdec.${i}.${keylen}.data.out`;
-        `openssl pkeyutl -decrypt -inkey rsa$keylen.key -in rsaencdec.${i}.${keylen}.data.out -out rsaencdec.${i}.${keylen}.data.dec`;
+        `$prov openssl pkeyutl -encrypt -pubin -inkey rsaencdec$keylen.pub -in rsaencdec.${i}.${keylen}.data.in -out rsaencdec.${i}.${keylen}.data.out`;
+        `openssl pkeyutl -decrypt -inkey rsaencdec$keylen.key -in rsaencdec.${i}.${keylen}.data.out -out rsaencdec.${i}.${keylen}.data.dec`;
         `cmp rsaencdec.${i}.${keylen}.data.in rsaencdec.${i}.${keylen}.data.dec`;
         exit(99) if ($?);
         `rm -f rsaencdec.${i}.${keylen}.data.in rsaencdec.${i}.${keylen}.data.out rsaencdec.${i}.${keylen}.data.dec`;
 
         # no-provider enc, provider dec
         `openssl rand $bytes > rsaencdec.${i}.${keylen}.data.in`;
-        `openssl pkeyutl -encrypt -pubin -inkey rsa$keylen.pub -in rsaencdec.${i}.${keylen}.data.in -out rsaencdec.${i}.${keylen}.data.out`;
-        `$prov openssl pkeyutl -decrypt -inkey rsa$keylen.key -in rsaencdec.${i}.${keylen}.data.out -out rsaencdec.${i}.${keylen}.data.dec`;
+        `openssl pkeyutl -encrypt -pubin -inkey rsaencdec$keylen.pub -in rsaencdec.${i}.${keylen}.data.in -out rsaencdec.${i}.${keylen}.data.out`;
+        `$prov openssl pkeyutl -decrypt -inkey rsaencdec$keylen.key -in rsaencdec.${i}.${keylen}.data.out -out rsaencdec.${i}.${keylen}.data.dec`;
         `cmp rsaencdec.${i}.${keylen}.data.in rsaencdec.${i}.${keylen}.data.dec`;
         exit(99) if ($?);
         `rm -f rsaencdec.${i}.${keylen}.data.in rsaencdec.${i}.${keylen}.data.out rsaencdec.${i}.${keylen}.data.dec`;
     }
 
-    `rm -f rsa$keylen.key rsa$keylen.pub`;
+    `rm -f rsaencdec$keylen.key rsaencdec$keylen.pub`;
 }
 
 sub rsaoaepencdec {
@@ -63,24 +63,24 @@ sub rsaoaepencdec {
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsa$keylen.key`;
-    `$prov openssl rsa -in rsa$keylen.key -check -pubout -out rsa$keylen.pub`;
+    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsaoaepencdec$keylen.key`;
+    `$prov openssl rsa -in rsaoaepencdec$keylen.key -check -pubout -out rsaoaepencdec$keylen.pub`;
     exit(99) if ($?);
 
     for my $i (1..$tests) {
         my $bytes = 1 + int(rand($max_file_size));
         # provider enc, no-provider dec
         `openssl rand $bytes > rsaoaepencdec.${i}.${keylen}.data.in`;
-        `$prov openssl pkeyutl -encrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -pubin -inkey rsa$keylen.pub -in rsaoaepencdec.${i}.${keylen}.data.in -out rsaoaepencdec.${i}.${keylen}.data.out`;
-        `openssl pkeyutl -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -inkey rsa$keylen.key -in rsaoaepencdec.${i}.${keylen}.data.out -out rsaoaepencdec.${i}.${keylen}.data.dec`;
+        `$prov openssl pkeyutl -encrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -pubin -inkey rsaoaepencdec$keylen.pub -in rsaoaepencdec.${i}.${keylen}.data.in -out rsaoaepencdec.${i}.${keylen}.data.out`;
+        `openssl pkeyutl -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -inkey rsaoaepencdec$keylen.key -in rsaoaepencdec.${i}.${keylen}.data.out -out rsaoaepencdec.${i}.${keylen}.data.dec`;
         `cmp rsaoaepencdec.${i}.${keylen}.data.in rsaoaepencdec.${i}.${keylen}.data.dec`;
         exit(99) if ($?);
         `rm -f rsaoaepencdec.${i}.${keylen}.data.in rsaoaepencdec.${i}.${keylen}.data.out rsaoaepencdec.${i}.${keylen}.data.dec`;
 
         # no-provider enc, provider dec
         `openssl rand $bytes > rsaoaepencdec.${i}.${keylen}.data.in`;
-        `openssl pkeyutl -encrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -pubin -inkey rsa$keylen.pub -in rsaoaepencdec.${i}.${keylen}.data.in -out rsaoaepencdec.${i}.${keylen}.data.out`;
-        `$prov openssl pkeyutl -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -inkey rsa$keylen.key -in rsaoaepencdec.${i}.${keylen}.data.out -out rsaoaepencdec.${i}.${keylen}.data.dec`;
+        `openssl pkeyutl -encrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -pubin -inkey rsaoaepencdec$keylen.pub -in rsaoaepencdec.${i}.${keylen}.data.in -out rsaoaepencdec.${i}.${keylen}.data.out`;
+        `$prov openssl pkeyutl -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:$md -inkey rsaoaepencdec$keylen.key -in rsaoaepencdec.${i}.${keylen}.data.out -out rsaoaepencdec.${i}.${keylen}.data.dec`;
         `cmp rsaoaepencdec.${i}.${keylen}.data.in rsaoaepencdec.${i}.${keylen}.data.dec`;
         exit(99) if ($?);
         `rm -f rsaoaepencdec.${i}.${keylen}.data.in rsaoaepencdec.${i}.${keylen}.data.out rsaoaepencdec.${i}.${keylen}.data.dec`;
@@ -97,30 +97,30 @@ sub rsasignverify {
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsa$keylen.key`;
-    `$prov openssl rsa -in rsa$keylen.key -check -pubout -out rsa$keylen.pub`;
+    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsasignverify$keylen.key`;
+    `$prov openssl rsa -in rsasignverify$keylen.key -check -pubout -out rsasignverify$keylen.pub`;
     exit(99) if ($?);
 
     for my $i (1..$tests) {
         my $bytes = 1 + int(rand($input_size));
         # provider sign, no-provider verify
         `openssl rand $bytes > rsasignverify.${i}.${keylen}.data.in`;
-        `$prov openssl pkeyutl -sign -inkey rsa$keylen.key -in rsasignverify.${i}.${keylen}.data.in -out rsasignverify.${i}.${keylen}.data.out`;
-        `openssl pkeyutl -verifyrecover -pubin -inkey rsa$keylen.pub -in rsasignverify.${i}.${keylen}.data.out -out rsasignverify.${i}.${keylen}.data.rec`;
+        `$prov openssl pkeyutl -sign -inkey rsasignverify$keylen.key -in rsasignverify.${i}.${keylen}.data.in -out rsasignverify.${i}.${keylen}.data.out`;
+        `openssl pkeyutl -verifyrecover -pubin -inkey rsasignverify$keylen.pub -in rsasignverify.${i}.${keylen}.data.out -out rsasignverify.${i}.${keylen}.data.rec`;
         `cmp rsasignverify.${i}.${keylen}.data.in rsasignverify.${i}.${keylen}.data.rec`;
         exit(99) if ($?);
         `rm -f rsasignverify.${i}.${keylen}.data.in rsasignverify.${i}.${keylen}.data.out rsasignverify.${i}.${keylen}.data.rec`;
 
         # no-provider sign, provider verify
         `openssl rand $bytes > rsasignverify.${i}.${keylen}.data.in`;
-        `openssl pkeyutl -sign -inkey rsa$keylen.key -in rsasignverify.${i}.${keylen}.data.in -out rsasignverify.${i}.${keylen}.data.out`;
-        `$prov openssl pkeyutl -verifyrecover -pubin -inkey rsa$keylen.pub -in rsasignverify.${i}.${keylen}.data.out -out rsasignverify.${i}.${keylen}.data.rec`;
+        `openssl pkeyutl -sign -inkey rsasignverify$keylen.key -in rsasignverify.${i}.${keylen}.data.in -out rsasignverify.${i}.${keylen}.data.out`;
+        `$prov openssl pkeyutl -verifyrecover -pubin -inkey rsasignverify$keylen.pub -in rsasignverify.${i}.${keylen}.data.out -out rsasignverify.${i}.${keylen}.data.rec`;
         `cmp rsasignverify.${i}.${keylen}.data.in rsasignverify.${i}.${keylen}.data.rec`;
         exit(99) if ($?);
         `rm -f rsasignverify.${i}.${keylen}.data.in rsasignverify.${i}.${keylen}.data.out rsasignverify.${i}.${keylen}.data.rec`;
     }
 
-    `rm -f rsa$keylen.key rsa$keylen.pub`;
+    `rm -f rsasignverify$keylen.key rsasignverify$keylen.pub`;
 }
 
 sub rsapsssignverify {
@@ -165,28 +165,28 @@ sub rsax931signverify {
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsa$keylen.key`;
-    `$prov openssl rsa -in rsa$keylen.key -check -pubout -out rsa$keylen.pub`;
+    `$prov openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:$keylen -out rsax931$keylen.key`;
+    `$prov openssl rsa -in rsax931$keylen.key -check -pubout -out rsax931$keylen.pub`;
     exit(99) if ($?);
 
     for my $i (1..$tests) {
         my $bytes = 1 + int(rand($input_size));
         # provider sign, no-provider verify
         `openssl rand $bytes > rsax931signverify.${i}.${keylen}.data.in`;
-        `$prov openssl pkeyutl -sign -digest $md -pkeyopt rsa_padding_mode:x931 -inkey rsa$keylen.key -rawin -in rsax931signverify.${i}.${keylen}.data.in -out rsax931signverify.${i}.${keylen}.data.out`;
-        `openssl pkeyutl -verify -digest $md -pkeyopt rsa_padding_mode:x931 -pubin -inkey rsa$keylen.pub -rawin -in rsax931signverify.${i}.${keylen}.data.in -sigfile rsax931signverify.${i}.${keylen}.data.out`;
+        `$prov openssl pkeyutl -sign -digest $md -pkeyopt rsa_padding_mode:x931 -inkey rsax931$keylen.key -rawin -in rsax931signverify.${i}.${keylen}.data.in -out rsax931signverify.${i}.${keylen}.data.out`;
+        `openssl pkeyutl -verify -digest $md -pkeyopt rsa_padding_mode:x931 -pubin -inkey rsax931$keylen.pub -rawin -in rsax931signverify.${i}.${keylen}.data.in -sigfile rsax931signverify.${i}.${keylen}.data.out`;
         exit(99) if ($?);
         `rm -f rsax931signverify.${i}.${keylen}.data.in rsax931signverify.${i}.${keylen}.data.out`;
 
         # no-provider sign, provider verify
         `openssl rand $bytes > rsax931signverify.${i}.${keylen}.data.in`;
-        `openssl pkeyutl -sign -digest $md -pkeyopt rsa_padding_mode:x931 -inkey rsa$keylen.key -rawin -in rsax931signverify.${i}.${keylen}.data.in -out rsax931signverify.${i}.${keylen}.data.out`;
-        `$prov openssl pkeyutl -verify -digest $md -pkeyopt rsa_padding_mode:x931 -pubin -inkey rsa$keylen.pub -rawin -in rsax931signverify.${i}.${keylen}.data.in -sigfile rsax931signverify.${i}.${keylen}.data.out`;
+        `openssl pkeyutl -sign -digest $md -pkeyopt rsa_padding_mode:x931 -inkey rsax931$keylen.key -rawin -in rsax931signverify.${i}.${keylen}.data.in -out rsax931signverify.${i}.${keylen}.data.out`;
+        `$prov openssl pkeyutl -verify -digest $md -pkeyopt rsa_padding_mode:x931 -pubin -inkey rsax931$keylen.pub -rawin -in rsax931signverify.${i}.${keylen}.data.in -sigfile rsax931signverify.${i}.${keylen}.data.out`;
         exit(99) if ($?);
         `rm -f rsax931signverify.${i}.${keylen}.data.in rsax931signverify.${i}.${keylen}.data.out`;
     }
 
-    `rm -f rsa$keylen.key rsa$keylen.pub`;
+    `rm -f rsax931$keylen.key rsax931$keylen.pub`;
 }
 
 sub ecsignverify {
@@ -201,23 +201,23 @@ sub ecsignverify {
     `openssl ecparam -list_curves | grep $curve`;
     return if ($?);
 
-    `$prov openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:$curve -out ec$curve.key`;
-    `$prov openssl ec -in ec$curve.key -check -pubout -out ec$curve.pub`;
+    `$prov openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:$curve -out ecsignverify$curve.key`;
+    `$prov openssl ec -in ecsignverify$curve.key -check -pubout -out ecsignverify$curve.pub`;
     exit(99) if ($?);
 
     for my $i (1..$tests) {
         my $bytes = 1 + int(rand($input_size));
         # provider sign, no-provider verify
         `openssl rand $bytes > ecsignverify.${i}.${curve}.data.in`;
-        `$prov openssl pkeyutl -sign -digest $md -inkey ec$curve.key -rawin -in ecsignverify.${i}.${curve}.data.in -out ecsignverify.${i}.${curve}.data.out`;
-        `openssl pkeyutl -verify -digest $md -pubin -inkey ec$curve.pub -rawin -in ecsignverify.${i}.${curve}.data.in -sigfile ecsignverify.${i}.${curve}.data.out`;
+        `$prov openssl pkeyutl -sign -digest $md -inkey ecsignverify$curve.key -rawin -in ecsignverify.${i}.${curve}.data.in -out ecsignverify.${i}.${curve}.data.out`;
+        `openssl pkeyutl -verify -digest $md -pubin -inkey ecsignverify$curve.pub -rawin -in ecsignverify.${i}.${curve}.data.in -sigfile ecsignverify.${i}.${curve}.data.out`;
         exit(99) if ($?);
         `rm -f ecsignverify.${i}.${curve}.data.in ecsignverify.${i}.${curve}.data.out`;
 
         # no-provider sign, provider verify
         `openssl rand $bytes > ecsignverify.${i}.${curve}.data.in`;
-        `openssl pkeyutl -sign -digest $md -inkey ec$curve.key -rawin -in ecsignverify.${i}.${curve}.data.in -out ecsignverify.${i}.${curve}.data.out`;
-        `$prov openssl pkeyutl -verify -digest $md -pubin -inkey ec$curve.pub -rawin -in ecsignverify.${i}.${curve}.data.in -sigfile ecsignverify.${i}.${curve}.data.out`;
+        `openssl pkeyutl -sign -digest $md -inkey ecsignverify$curve.key -rawin -in ecsignverify.${i}.${curve}.data.in -out ecsignverify.${i}.${curve}.data.out`;
+        `$prov openssl pkeyutl -verify -digest $md -pubin -inkey ecsignverify$curve.pub -rawin -in ecsignverify.${i}.${curve}.data.in -sigfile ecsignverify.${i}.${curve}.data.out`;
         exit(99) if ($?);
         `rm -f ecsignverify.${i}.${curve}.data.in ecsignverify.${i}.${curve}.data.out`;
     }
@@ -285,24 +285,23 @@ sub dhderive {
     my $prov = "OPENSSL_CONF=$ENV{IBMCA_OPENSSL_TEST_CONF} OPENSSL_MODULES=$ENV{IBMCA_TEST_PATH}";
 
     my ($group, $tests) = @_;
-
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out dh$group.key`;
-    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out peer$group.key`;
-    `$prov openssl pkey -in peer$group.key -check -pubout -out peer$group.pub`;
+    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out dhderive$group.key`;
+    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out peerderive$group.key`;
+    `$prov openssl pkey -in peerderive$group.key -check -pubout -out peerderive$group.pub`;
     exit(99) if ($?);
 
     for my $i (1..$tests) {
-        `$prov openssl pkeyutl -derive -inkey dh$group.key -peerkey peer$group.pub -out dhderive.${i}.${group}.data.out1`;
-        `openssl pkeyutl -derive -inkey dh$group.key -peerkey peer$group.pub -out dhderive.${i}.${group}.data.out2`;
+        `$prov openssl pkeyutl -derive -inkey dhderive$group.key -peerkey peerderive$group.pub -out dhderive.${i}.${group}.data.out1`;
+        `openssl pkeyutl -derive -inkey dhderive$group.key -peerkey peerderive$group.pub -out dhderive.${i}.${group}.data.out2`;
         `cmp dhderive.${i}.${group}.data.out1 dhderive.${i}.${group}.data.out2`;
         exit(99) if ($?);
         `rm -f dhderive.${i}.${group}.data.out1 dhderive.${i}.${group}.data.out2`;
     }
 
-    `rm -f dh$group.key peer$group.key peer$group.pub`;
+    `rm -f dhderive$group.key peerderive$group.key peerderive$group.pub`;
 }
 
 sub dhderivekdf {
@@ -313,21 +312,21 @@ sub dhderivekdf {
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out dh$group.key`;
-    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out peer$group.key`;
-    `$prov openssl pkey -in peer$group.key -check -pubout -out peer$group.pub`;
+    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out dhderivekdf$group.key`;
+    `$prov openssl genpkey -algorithm DH -pkeyopt group:$group -out peerderivekdf$group.key`;
+    `$prov openssl pkey -in peerderivekdf$group.key -check -pubout -out peerderivekdf$group.pub`;
     exit(99) if ($?);
 
 
     for my $i (1..$tests) {
-        `$prov openssl pkeyutl -derive -inkey dh$group.key -peerkey peer$group.pub -pkeyopt kdf-type:$kdf -pkeyopt kdf-outlen:$outlen -pkeyopt kdf-digest:$md -pkeyopt cekalg:$cekalg -out dhderive.${i}.${group}.data.out1`;
-        `openssl pkeyutl -derive -inkey dh$group.key -peerkey peer$group.pub -pkeyopt kdf-type:$kdf -pkeyopt kdf-outlen:$outlen -pkeyopt kdf-digest:$md  -pkeyopt cekalg:$cekalg -out dhderive.${i}.${group}.data.out2`;
-        `cmp dhderive.${i}.${group}.data.out1 dhderive.${i}.${group}.data.out2`;
+        `$prov openssl pkeyutl -derive -inkey dhderivekdf$group.key -peerkey peerderivekdf$group.pub -pkeyopt kdf-type:$kdf -pkeyopt kdf-outlen:$outlen -pkeyopt kdf-digest:$md -pkeyopt cekalg:$cekalg -out dhderivekdf.${i}.${group}.data.out1`;
+        `openssl pkeyutl -derive -inkey dhderivekdf$group.key -peerkey peerderivekdf$group.pub -pkeyopt kdf-type:$kdf -pkeyopt kdf-outlen:$outlen -pkeyopt kdf-digest:$md  -pkeyopt cekalg:$cekalg -out dhderivekdf.${i}.${group}.data.out2`;
+        `cmp dhderivekdf.${i}.${group}.data.out1 dhderivekdf.${i}.${group}.data.out2`;
         exit(99) if ($?);
-        `rm -f dhderive.${i}.${group}.data.out1 dhderive.${i}.${group}.data.out2`;
+        `rm -f dhderivekdf.${i}.${group}.data.out1 dhderivekdf.${i}.${group}.data.out2`;
     }
 
-    `rm -f dh$group.key peer$group.key peer$group.pub`;
+    `rm -f dhderivekdf$group.key peerderivekdf$group.key peerderivekdf$group.pub`;
 }
 
 sub tls {
@@ -339,12 +338,16 @@ sub tls {
     `$prov openssl list -providers | grep "name: ibmca"`;
     exit(99) if ($?);
 
-    `$prov openssl s_server -accept $port -naccept 1 -brief -cert $cert -key $privkey -cipher $cipher -ciphersuites $ciphersuites $opts 1>server-$port.out 2>&1 &`;
-    sleep 1;
-    `echo "Hello World" | $prov openssl s_client -connect localhost:$port -cipher $cipher -ciphersuites $ciphersuites $opts`;
-    $ret = $?;
-    sleep 1;
-   `killall openssl`;
+    if ($pid = fork) {
+	sleep 1;
+	`echo "Hello World" | $prov openssl s_client -connect localhost:$port -cipher $cipher -ciphersuites $ciphersuites $opts`;
+	$ret = $?;
+	sleep 1;
+	kill 15, $pid;
+	waitpid $pid, 0;
+    } else {
+	exec "$prov openssl s_server -accept $port -naccept 1 -brief -cert $cert -key $privkey -cipher $cipher -ciphersuites $ciphersuites $opts 1>server-$port.out 2>&1";
+    }
     exit(99) if ($ret);
 
    `rm -f server-$port.out`;


### PR DESCRIPTION
Make key file names unique and do not use killall.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>