### PR TITLE
provider: Support EC parameter generation with named curve

### DIFF
--- a/src/provider/p_ibmca.h
+++ b/src/provider/p_ibmca.h
@@ -216,6 +216,7 @@ struct ibmca_op_ctx {
         } rsa; /* For type EVP_PKEY_RSA and EVP_PKEY_RSA_PSS */
         union {
             struct {
+                int selection;
                 int curve_nid;
                 point_conversion_form_t format;
             } gen; /* For operation EVP_PKEY_OP_KEYGEN */


### PR DESCRIPTION
In general the IBMCA provider does not support EC parameter generation, because libica only supports certain named curves. However, one can also use EC parameter generation with a named curve, and then use such parameter key object as template for generating other keys. One example for this is the openssl speed utility.

Like for EC key generation, EC parameter generation only supports parameters 'group', 'point-format', 'encoding', and 'use-cofactor-flag', where the only accepted value for parameter 'encoding' is 'named_curve', and the only accepted value for parameter 'use-cofactor-flag' is '0'.

With this change the openssl speed utility works fine with ECDSA.
