### PR TITLE
engine: EC: Cache ICA key in EC_KEY object

### DIFF
--- a/src/engine/e_ibmca.c
+++ b/src/engine/e_ibmca.c
@@ -833,6 +833,11 @@ static int ibmca_init(ENGINE *e)
         goto err;
     }
 
+#ifndef NO_EC
+    if (!ibmca_ec_init())
+        goto err;
+#endif
+
     if (!set_supported_meths(e))
         goto err;
 

--- a/src/engine/ibmca.h
+++ b/src/engine/ibmca.h
@@ -298,6 +298,7 @@ void ibmca_dh_destroy(void);
 #define IBMCA_EC_MAX_Z_LEN	IBMCA_EC_MAX_D_LEN
 
 #ifndef OPENSSL_NO_EC
+int ibmca_ec_init(void);
 void ibmca_ec_destroy(void);
 
 int ibmca_ecdh_compute_key(unsigned char **pout, size_t *poutlen,

--- a/src/engine/ibmca_ec.c
+++ b/src/engine/ibmca_ec.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdlib.h>
+#include <pthread.h>
 #include "ibmca.h"
 #include "e_ibmca_err.h"
 
@@ -31,6 +32,251 @@ ica_ec_key_get_public_key_t	p_ica_ec_key_get_public_key;
 ica_ec_key_get_private_key_t	p_ica_ec_key_get_private_key;
 ica_ec_key_free_t		p_ica_ec_key_free;
 
+int ec_ex_data_index = -1;
+pthread_mutex_t ec_ex_data_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+struct ibmca_ec_ex_data {
+    ICA_EC_KEY *ica_key;
+    int nid;
+    unsigned int privlen;
+};
+
+void ibmca_ec_ex_data_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                           int idx, long argl, void *argp)
+{
+    struct ibmca_ec_ex_data *data = ptr;
+
+    if (data == NULL)
+        return;
+
+    p_ica_ec_key_free(data->ica_key);
+    OPENSSL_free(data);
+}
+
+int ibmca_ec_ex_data_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
+#ifdef OPENSSL_VERSION_PREREQ
+                         void **pptr, int idx, long argl, void *argp)
+#else
+                         void *from_d, int idx, long argl, void *argp)
+#endif
+{
+#ifndef OPENSSL_VERSION_PREREQ
+    void **pptr = (void **)from_d;
+#endif
+    struct ibmca_ec_ex_data *from_data;
+    struct ibmca_ec_ex_data *to_data;
+    unsigned char Q[2 * IBMCA_EC_MAX_D_LEN];
+    unsigned char D[IBMCA_EC_MAX_D_LEN];
+    unsigned int len;
+    int rc;
+
+    if (pptr == NULL)
+        return 0;
+
+    from_data = (struct ibmca_ec_ex_data *)*pptr;
+    if (from_data == NULL)
+        return 0;
+
+    to_data = OPENSSL_zalloc(sizeof(*to_data));
+    if (to_data == NULL) {
+       return 0;
+    }
+
+    to_data->nid = from_data->nid;
+    to_data->ica_key = p_ica_ec_key_new(to_data->nid, &to_data->privlen);
+    if (to_data->ica_key == NULL) {
+        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_ICA_EC_KEY_INIT);
+        goto error;
+    }
+
+    if (p_ica_ec_key_get_private_key(from_data->ica_key, D, &len) == 0) {
+        rc = p_ica_ec_key_init(NULL, NULL, D, to_data->ica_key);
+        if (rc != 0) {
+            IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
+            goto error;
+        }
+    }
+
+    if (p_ica_ec_key_get_public_key(from_data->ica_key, Q, &len) == 0) {
+        rc = p_ica_ec_key_init(Q, Q + to_data->privlen, NULL, to_data->ica_key);
+        if (rc != 0) {
+            IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
+            goto error;
+        }
+    }
+
+    *pptr = to_data;
+
+    return 1;
+
+error:
+    if (to_data->ica_key != NULL)
+        p_ica_ec_key_free(to_data->ica_key);
+    OPENSSL_free(to_data);
+
+    return 0;
+}
+
+static ICA_EC_KEY *ibmca_ec_make_ica_key(EC_KEY *ec_key, int *nid,
+                                         unsigned int *privlen)
+{
+    ICA_EC_KEY *icakey;
+    const EC_GROUP *group;
+    const EC_POINT *q;
+    const BIGNUM *bn_d;
+    BIGNUM *bn_x = NULL, *bn_y = NULL;
+    unsigned char D[IBMCA_EC_MAX_D_LEN];
+    unsigned char X[IBMCA_EC_MAX_D_LEN];
+    unsigned char Y[IBMCA_EC_MAX_D_LEN];
+    int rc, n;
+
+    /* Get group */
+    if ((group = EC_KEY_get0_group(ec_key)) == NULL) {
+        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_INVALID_PARM);
+        return NULL;
+    }
+
+    /* Get curve nid */
+    *nid = EC_GROUP_get_curve_name(group);
+    if (*nid <= 0) {
+        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_UNSUPPORTED_CURVE);
+        return NULL;
+    }
+
+    /* Create ICA_EC_KEY object */
+    icakey = p_ica_ec_key_new(*nid, privlen);
+    if (icakey == NULL) {
+        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_ICA_EC_KEY_INIT);
+        return NULL;
+    }
+
+    /* Get private (D) value from EC_KEY (if available) */
+    bn_d = EC_KEY_get0_private_key(ec_key);
+    if (bn_d != NULL) {
+        /* Format (D) as char array, with leading zeros if necessary */
+        n = *privlen - BN_num_bytes(bn_d);
+        memset(D, 0, n);
+        BN_bn2bin(bn_d, &(D[n]));
+
+        /* Initialize private ICA_EC_KEY */
+        rc = p_ica_ec_key_init(NULL, NULL, D, icakey);
+        if (rc != 0) {
+            IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
+            goto error;
+        }
+    }
+
+    /* Get public (X and Y) values from EC_KEY (if available) */
+    q = EC_KEY_get0_public_key(ec_key);
+    if (q != NULL) {
+        /* Provide public key (X,Y) */
+        bn_x = BN_new();
+        bn_y = BN_new();
+        if (!EC_POINT_get_affine_coordinates_GFp(group, q, bn_x, bn_y, NULL)) {
+            IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_INTERNAL_ERROR);
+            goto error;
+        }
+
+        /* Format (X) as char array with leading nulls if necessary */
+        n = *privlen - BN_num_bytes(bn_x);
+        memset(X, 0, n);
+        BN_bn2bin(bn_x, &X[n]);
+
+        /* Format (Y) as char array with leading nulls if necessary */
+        n = *privlen - BN_num_bytes(bn_y);
+        memset(Y, 0, n);
+        BN_bn2bin(bn_y, &Y[n]);
+
+        /* Initialize public ICA_EC_KEY */
+        rc = p_ica_ec_key_init(X, Y, NULL, icakey);
+        if (rc != 0) {
+            IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
+            goto error;
+        }
+    }
+
+out:
+    BN_clear_free(bn_x);
+    BN_clear_free(bn_y);
+
+    return icakey;
+
+error:
+    p_ica_ec_key_free(icakey);
+    icakey = NULL;
+    goto out;
+}
+
+static ICA_EC_KEY *ibmca_ec_make_and_cache_ica_key(EC_KEY *ec_key,
+                                                   unsigned int *privlen)
+{
+    struct ibmca_ec_ex_data *data, *data2;
+
+    data = OPENSSL_zalloc(sizeof(*data));
+    if (data == NULL)
+        return NULL;
+
+    data->ica_key = ibmca_ec_make_ica_key(ec_key, &data->nid, &data->privlen);
+    if (data->ica_key == NULL) {
+        OPENSSL_free(data);
+        return NULL;
+    }
+
+    /*
+     * Note that another thread could have allocated and set the ex_data for
+     * that key after the caller of this function has checked if there is
+     * already ex_data available for the key. So once we have the lock, we
+     * check again, and if there now is ex_data available, we return the
+     * ICA key from the ex_data, and free the one just created.
+     */
+    if (pthread_mutex_lock(&ec_ex_data_mutex) != 0) {
+        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_INTERNAL_ERROR);
+        return NULL;
+    }
+
+    data2 = EC_KEY_get_ex_data(ec_key, ec_ex_data_index);
+    if (data2 != NULL) {
+        pthread_mutex_unlock(&ec_ex_data_mutex);
+
+        p_ica_ec_key_free(data->ica_key);
+        OPENSSL_free(data);
+
+        *privlen = data2->privlen;
+
+        return data2->ica_key;
+    }
+
+    if (EC_KEY_set_ex_data(ec_key, ec_ex_data_index, data) != 1) {
+        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_INTERNAL_ERROR);
+        pthread_mutex_unlock(&ec_ex_data_mutex);
+        OPENSSL_free(data);
+        return NULL;
+    }
+
+    pthread_mutex_unlock(&ec_ex_data_mutex);
+
+    *privlen = data->privlen;
+
+    return data->ica_key;
+}
+
+int ibmca_ec_init(void)
+{
+#ifdef OLDER_OPENSSL
+    return 0;
+#else
+    ec_ex_data_index = EC_KEY_get_ex_new_index(0, NULL, NULL,
+                                               ibmca_ec_ex_data_dup,
+                                               ibmca_ec_ex_data_free);
+    if (ec_ex_data_index < 0) {
+        IBMCAerr(IBMCA_F_IBMCA_INIT, IBMCA_R_EC_INTERNAL_ERROR);
+        return 0;
+    }
+
+    return 1;
+#endif
+}
+
 void ibmca_ec_destroy(void)
 {
  #ifdef OLDER_OPENSSL
@@ -39,6 +285,10 @@ void ibmca_ec_destroy(void)
     if (ibmca_ecdh)
         ECDSA_METHOD_free(ibmca_ecdsa);
  #else
+    if (ec_ex_data_index >= 0) {
+        CRYPTO_free_ex_index(CRYPTO_EX_INDEX_EC_KEY, ec_ex_data_index);
+        ec_ex_data_index = -1;
+    }
     if (ibmca_ec)
         EC_KEY_METHOD_free(ibmca_ec);
  #endif
@@ -55,17 +305,17 @@ int ibmca_ecdh_compute_key(unsigned char **pout, size_t *poutlen,
 {
     ICA_EC_KEY *ica_pubkey = NULL, *ica_privkey = NULL;
     const EC_GROUP *group;
-    BIGNUM *bn_d, *bn_x, *bn_y;
+    BIGNUM *bn_x = NULL, *bn_y = NULL;
     unsigned int n, privlen;
     unsigned char X[IBMCA_EC_MAX_D_LEN];
     unsigned char Y[IBMCA_EC_MAX_D_LEN];
-    unsigned char D[IBMCA_EC_MAX_D_LEN];
     unsigned char *z_buf = NULL;
     int rc, ret = 0, nid;
  #ifndef OLDER_OPENSSL
     int (*compute_key_sw)(unsigned char **pout, size_t *poutlen,
                           const EC_POINT *pub_key, const EC_KEY *ecdh) = NULL;
  #endif
+    struct ibmca_ec_ex_data *data = EC_KEY_get_ex_data(ecdh, ec_ex_data_index);
 
     /* Get group from EC_KEY */
     if ((group = EC_KEY_get0_group(ecdh)) == NULL) {
@@ -76,10 +326,40 @@ int ibmca_ecdh_compute_key(unsigned char **pout, size_t *poutlen,
     /* Determine curve nid */
     nid = EC_GROUP_get_curve_name(group);
     if (nid <= 0) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDH_COMPUTE_KEY, IBMCA_R_EC_INTERNAL_ERROR);
+        IBMCAerr(IBMCA_F_IBMCA_ECDH_COMPUTE_KEY, IBMCA_R_EC_UNSUPPORTED_CURVE);
         return 0;
     }
 
+    if (data != NULL) {
+        ica_privkey = data->ica_key;
+        privlen = data->privlen;
+        goto do_derive;
+    }
+
+    /* Create ICA_EC_KEY object for private key */
+    ica_privkey = ibmca_ec_make_and_cache_ica_key((EC_KEY*)ecdh, &privlen);
+    if (ica_privkey == NULL) {
+        /* This curve is not supported by libica. */
+    #ifdef OLDER_OPENSSL
+        return 0;
+    #else
+        /*
+         * EC_KEY_METHOD_get_compute_key misses the const-qualifier of the
+         * parameter in some openssl versions.
+         */
+        EC_KEY_METHOD_get_compute_key((EC_KEY_METHOD *)ossl_ec,
+                                      &compute_key_sw);
+        if (compute_key_sw == NULL) {
+            IBMCAerr(IBMCA_F_IBMCA_ECDH_COMPUTE_KEY,
+                     IBMCA_R_EC_INTERNAL_ERROR);
+            return 0;
+        }
+
+        return compute_key_sw(pout, poutlen, pub_key, ecdh);
+    #endif
+    }
+
+do_derive:
     /* Create ICA_EC_KEY object for public key */
     ica_pubkey = p_ica_ec_key_new(nid, &privlen);
     if (ica_pubkey == NULL) {
@@ -128,32 +408,6 @@ int ibmca_ecdh_compute_key(unsigned char **pout, size_t *poutlen,
         goto end;
     }
 
-    /* Create ICA_EC_KEY object for private key */
-    ica_privkey = p_ica_ec_key_new(nid, &privlen);
-    if (!ica_privkey) {
-        IBMCAerr(IBMCA_F_ICA_EC_KEY_NEW, IBMCA_R_EC_INTERNAL_ERROR);
-        goto end;
-    }
-
-    /* Get private (D) value from EC_KEY */
-    bn_d = (BIGNUM*)EC_KEY_get0_private_key((EC_KEY*)ecdh);
-    if (bn_d == NULL) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDH_COMPUTE_KEY, IBMCA_R_EC_INTERNAL_ERROR);
-        goto end;
-    }
-
-    /* Format (D) as char array, with leading zeros if necessary */
-    n = privlen - BN_num_bytes(bn_d);
-    memset(D, 0, n);
-    BN_bn2bin(bn_d, &(D[n]));
-
-    /* Initialize private ICA_EC_KEY with (D) */
-    rc = p_ica_ec_key_init(NULL, NULL, D, ica_privkey);
-    if (rc != 0) {
-        IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
-        goto end;
-    }
-
     /* Allocate memory for shared secret z, will be freed by caller */
     if ((z_buf = OPENSSL_malloc(privlen)) == NULL) {
         IBMCAerr(IBMCA_F_IBMCA_ECDH_COMPUTE_KEY, IBMCA_R_EC_INTERNAL_ERROR);
@@ -193,7 +447,6 @@ int ibmca_ecdh_compute_key(unsigned char **pout, size_t *poutlen,
 
 end:
     p_ica_ec_key_free(ica_pubkey);
-    p_ica_ec_key_free(ica_privkey);
     BN_clear_free(bn_x);
     BN_clear_free(bn_y);
     return ret;
@@ -210,12 +463,10 @@ ECDSA_SIG *ibmca_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
 {
     ECDSA_SIG *sig = NULL;
     ICA_EC_KEY *icakey = NULL;
-    const EC_GROUP *group;
     unsigned int privlen;
-    BIGNUM *r, *s, *bn_d, *kinv;
-    unsigned char D[IBMCA_EC_MAX_D_LEN];
+    BIGNUM *r, *s, *kinv;
     unsigned char sigret[IBMCA_EC_MAX_SIG_LEN];
-    int n, nid, rc;
+    int rc;
  #ifndef OLDER_OPENSSL
     int (*sign_sw)(int type, const unsigned char *dgst, int dlen,
                     unsigned char *sig, unsigned int *siglen,
@@ -227,15 +478,10 @@ ECDSA_SIG *ibmca_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
                               const BIGNUM *in_kinv, const BIGNUM *in_r,
                               EC_KEY *eckey) = NULL;
     BN_CTX *ctx;
+    struct ibmca_ec_ex_data *data = EC_KEY_get_ex_data(eckey, ec_ex_data_index);
 
     /* Check parms: precomputed (k,r) are not supported by ibmca */
     if (in_kinv != NULL || in_r != NULL) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDSA_SIGN_SIG, IBMCA_R_EC_INVALID_PARM);
-        return NULL;
-    }
-
-    /* Get group */
-    if ((group = EC_KEY_get0_group(eckey)) == NULL) {
         IBMCAerr(IBMCA_F_IBMCA_ECDSA_SIGN_SIG, IBMCA_R_EC_INVALID_PARM);
         return NULL;
     }
@@ -249,15 +495,14 @@ ECDSA_SIG *ibmca_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
     }
  #endif
 
-    /* Get curve nid */
-    nid = EC_GROUP_get_curve_name(group);
-    if (nid <= 0) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDSA_SIGN_SIG, IBMCA_R_EC_UNSUPPORTED_CURVE);
-        return NULL;
+    if (data != NULL) {
+        icakey = data->ica_key;
+        privlen = data->privlen;
+        goto do_sign;
     }
 
     /* Create ICA_EC_KEY object */
-    icakey = p_ica_ec_key_new(nid, &privlen);
+    icakey = ibmca_ec_make_and_cache_ica_key(eckey, &privlen);
     if (icakey == NULL) {
         /* This curve is not supported by libica. */
  #ifdef OLDER_OPENSSL
@@ -287,25 +532,7 @@ ECDSA_SIG *ibmca_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
         return sig;
     }
 
-    /* Get private (D) value from EC_KEY */
-    bn_d = (BIGNUM*)EC_KEY_get0_private_key(eckey);
-    if (bn_d == NULL) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDSA_SIGN_SIG, IBMCA_R_EC_INTERNAL_ERROR);
-        goto end;
-    }
-
-    /* Format (D) as char array, with leading zeros if necessary */
-    n = privlen - BN_num_bytes(bn_d);
-    memset(D, 0, n);
-    BN_bn2bin(bn_d, &(D[n]));
-
-    /* Initialize private ICA_EC_KEY */
-    rc = p_ica_ec_key_init(NULL, NULL, D, icakey);
-    if (rc != 0) {
-        IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
-        goto end;
-    }
-
+do_sign:
     /* Call libica signing routine */
     rc = p_ica_ecdsa_sign(ibmca_handle, icakey, dgst, dgst_len, sigret,
                           sizeof(sigret));
@@ -343,7 +570,6 @@ ECDSA_SIG *ibmca_ecdsa_sign_sig(const unsigned char *dgst, int dgst_len,
     s = BN_bin2bn(sigret + privlen, privlen, NULL);
     sig = ECDSA_SIG_new();
 
-end:
  #ifndef OLDER_OPENSSL
     if (sig)
         ECDSA_SIG_set0(sig, r, s);
@@ -357,7 +583,6 @@ end:
  #endif
 
 end2:
-    p_ica_ec_key_free(icakey);
     return sig;
 }
 
@@ -372,16 +597,12 @@ end2:
 int ibmca_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
                            const ECDSA_SIG *sig, EC_KEY *eckey)
 {
-    const EC_GROUP *group;
-    const EC_POINT *q;
-    unsigned char x_array[IBMCA_EC_MAX_D_LEN];
-    unsigned char y_array[IBMCA_EC_MAX_D_LEN];
     unsigned char sig_array[IBMCA_EC_MAX_Q_LEN];
     BIGNUM *bn_x = NULL, *bn_y = NULL;
     const BIGNUM *bn_r, *bn_s;
     unsigned int privlen;
     ICA_EC_KEY *icakey = NULL;
-    int rc, n, nid;
+    int rc, n;
     int ret = -1;
 #ifndef OLDER_OPENSSL
     int (*verify_sw)(int type, const unsigned char *dgst, int dgst_len,
@@ -389,6 +610,7 @@ int ibmca_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
 #endif
     int (*verify_sig_sw)(const unsigned char *dgst, int dgst_len,
                          const ECDSA_SIG *sig, EC_KEY *eckey) = NULL;
+    struct ibmca_ec_ex_data *data = EC_KEY_get_ex_data(eckey, ec_ex_data_index);
 
     /* Check parms */
     if (eckey == NULL || sig == NULL) {
@@ -404,21 +626,14 @@ int ibmca_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
     }
  #endif
 
-    /* Get group */
-    if ((group = EC_KEY_get0_group(eckey)) == NULL) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDSA_VERIFY_SIG, IBMCA_R_EC_INTERNAL_ERROR);
-        return ret;
-    }
-
-    /* Get curve nid */
-    nid = EC_GROUP_get_curve_name(group);
-    if (nid <= 0) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDSA_VERIFY_SIG, IBMCA_R_EC_UNSUPPORTED_CURVE);
-        return ret;
+    if (data != NULL) {
+        icakey = data->ica_key;
+        privlen = data->privlen;
+        goto do_verify;
     }
 
     /* Create ICA_EC_KEY object */
-    icakey = p_ica_ec_key_new(nid, &privlen);
+    icakey = ibmca_ec_make_and_cache_ica_key(eckey, &privlen);
     if (icakey == NULL) {
         /* This curve is not supported by libica. */
  #ifdef OLDER_OPENSSL
@@ -440,32 +655,7 @@ int ibmca_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
         return verify_sig_sw(dgst, dgst_len, sig, eckey);
     }
 
-    /* Provide public key (X,Y) */
-    bn_x = BN_new();
-    bn_y = BN_new();
-    q = EC_KEY_get0_public_key(eckey);
-    if (!EC_POINT_get_affine_coordinates_GFp(group, q, bn_x, bn_y, NULL)) {
-        IBMCAerr(IBMCA_F_IBMCA_ECDSA_VERIFY_SIG, IBMCA_R_EC_INTERNAL_ERROR);
-        goto end;
-    }
-
-    /* Format (X) as char array with leading nulls if necessary */
-    n = privlen - BN_num_bytes(bn_x);
-    memset(x_array, 0, n);
-    BN_bn2bin(bn_x, &(x_array[n]));
-
-    /* Format (Y) as char array with leading nulls if necessary */
-    n = privlen - BN_num_bytes(bn_y);
-    memset(y_array, 0, n);
-    BN_bn2bin(bn_y, &(y_array[n]));
-
-    /* Initialize ICA_EC_KEY */
-    rc = p_ica_ec_key_init(x_array, y_array, NULL, icakey);
-    if (rc != 0) {
-        IBMCAerr(IBMCA_F_ICA_EC_KEY_INIT, rc);
-        goto end;
-    }
-
+do_verify:
     /* Get (r,s) from ECDSA_SIG */
  #ifdef OLDER_OPENSSL
     bn_r = sig->r;
@@ -517,7 +707,6 @@ int ibmca_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
     }
 
 end:
-    p_ica_ec_key_free(icakey);
     BN_clear_free(bn_x);
     BN_clear_free(bn_y);
 


### PR DESCRIPTION
Creating a new ICA EC key via ica_ec_key_init() is time consuming, because libica performs EC key checks on the key components.

Currently every sign, verify or derive operation creates a new ICA key, and thus suffers from the long taking EC key checks with every operation.

Change this to create an ICA key on the first usage of an EC key, and attach the ICA key to the EC_KEY object as ex-data. That way, subsequent operations using the same key will reuse the attached ICA key and do not have to create a new ICA key again.