### PR TITLE
Provider currency

### DIFF
--- a/src/provider/dh_keymgmt.c
+++ b/src/provider/dh_keymgmt.c
@@ -1758,6 +1758,10 @@ static int ibmca_keymgmt_dh_import(void *vkey, int selection,
 
         rc = ibmca_param_get_bn(key->provctx, params,
                                 OSSL_PKEY_PARAM_PRIV_KEY, &key->dh.priv);
+        if (rc <= 0) {
+            BN_clear_free(key->dh.priv);
+            key->dh.priv = NULL;
+        }
         if (rc == 0)
             return 0;
      }

--- a/src/provider/ec_keymgmt.c
+++ b/src/provider/ec_keymgmt.c
@@ -1080,6 +1080,15 @@ static int ibmca_keymgmt_ec_gen_set_params(void *vgenctx,
         }
     }
 
+#ifdef OSSL_PKEY_PARAM_DHKEM_IKM
+    if (OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DHKEM_IKM) != NULL) {
+        put_error_op_ctx(genctx, IBMCA_ERR_INVALID_PARAM,
+                         "EC parameter '%s' is not supported",
+                         OSSL_PKEY_PARAM_DHKEM_IKM);
+        return 0;
+    }
+#endif
+
     return 1;
 }
 

--- a/src/provider/ec_keymgmt.c
+++ b/src/provider/ec_keymgmt.c
@@ -1390,10 +1390,10 @@ static int ibmca_keymgmt_ec_priv_key_from_data(const struct ibmca_key *key,
     }
 
     rc = ibmca_param_get_bn(key->provctx, params, OSSL_PKEY_PARAM_PRIV_KEY, d);
-    if (rc == 0) {
+    if (rc <= 0) {
         BN_clear_free(*d);
         *d = NULL;
-        return 0;
+        return rc;
     }
 
    return 1;

--- a/src/provider/ec_signature.c
+++ b/src/provider/ec_signature.c
@@ -708,6 +708,9 @@ static int ibmca_signature_ec_set_ctx_params(void *vctx,
     const OSSL_PARAM *p;
     const char *name, *props = NULL;
     size_t md_size;
+#ifdef OSSL_SIGNATURE_PARAM_NONCE_TYPE
+    unsigned int nonce_type;
+#endif
     int rc;
 
     if (ctx == NULL)
@@ -746,6 +749,20 @@ static int ibmca_signature_ec_set_ctx_params(void *vctx,
         ctx->ec.signature.md_size = md_size;
     }
 
+#ifdef OSSL_SIGNATURE_PARAM_NONCE_TYPE
+    /* OSSL_SIGNATURE_PARAM_NONCE_TYPE */
+    rc = ibmca_param_get_uint(ctx->provctx, params,
+                              OSSL_SIGNATURE_PARAM_NONCE_TYPE, &nonce_type);
+    if (rc == 0)
+        return 0;
+    /* Only allow nonce_type = 0 = random K */
+    if (nonce_type != 0) {
+        put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                         "Deterministic signature is not supported");
+        return 0;
+    }
+#endif
+
     return 1;
 }
 
@@ -776,6 +793,9 @@ static const OSSL_PARAM ibmca_signature_ec_settable_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+#ifdef OSSL_SIGNATURE_PARAM_NONCE_TYPE
+    OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, NULL),
+#endif
     OSSL_PARAM_END
 };
 

--- a/src/provider/rsa_asym_cipher.c
+++ b/src/provider/rsa_asym_cipher.c
@@ -218,6 +218,15 @@ static int ibmca_asym_cipher_rsa_get_ctx_params(void *vctx, OSSL_PARAM params[])
     if (rc == 0)
         return 0;
 
+#ifdef OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION
+    /* OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION */
+    rc = ibmca_param_build_set_uint(ctx->provctx, NULL, params,
+                                    OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION,
+                                    0);
+    if (rc == 0)
+        return 0;
+#endif
+
     return 1;
 }
 
@@ -230,6 +239,9 @@ static int ibmca_asym_cipher_rsa_set_ctx_params(void *vctx,
     void *label = NULL;
     size_t labellen = 0;
     int i, rc;
+#ifdef OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION
+    unsigned int implicit_rejection;
+#endif
 
     if (ctx == NULL)
         return 0;
@@ -374,6 +386,19 @@ static int ibmca_asym_cipher_rsa_set_ctx_params(void *vctx,
     if (rc == 0)
         return 0;
 
+#ifdef OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION
+    rc = ibmca_param_get_uint(ctx->provctx, params,
+                              OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION,
+                              &implicit_rejection);
+    if (rc == 0)
+        return 0;
+    if (rc > 0 && implicit_rejection != 0) {
+        put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                         "RSA: Implicit rejection is not supported");
+        return 0;
+    }
+#endif
+
     return 1;
 }
 
@@ -384,6 +409,9 @@ static const OSSL_PARAM ibmca_asym_cipher_rsa_gettable_params[] = {
     OSSL_PARAM_octet_ptr(OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL, NULL, 0),
     OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION, NULL),
     OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION, NULL),
+#ifdef OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION
+    OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION, NULL),
+#endif
     OSSL_PARAM_END
 };
 
@@ -412,6 +440,9 @@ static const OSSL_PARAM ibmca_asym_cipher_rsa_settable_params[] = {
     OSSL_PARAM_octet_string(OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL, NULL, 0),
     OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION, NULL),
     OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION, NULL),
+#ifdef OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION
+    OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION, NULL),
+#endif
     OSSL_PARAM_END
 };
 

--- a/src/provider/rsa_asym_cipher.c
+++ b/src/provider/rsa_asym_cipher.c
@@ -213,7 +213,7 @@ static int ibmca_asym_cipher_rsa_get_ctx_params(void *vctx, OSSL_PARAM params[])
 
     /* OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION */
     rc = ibmca_param_build_set_uint(ctx->provctx, NULL, params,
-                                    OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION,
+                                    OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION,
                                     ctx->rsa.cipher.tls_alt_version);
     if (rc == 0)
         return 0;

--- a/src/provider/rsa_keymgmt.c
+++ b/src/provider/rsa_keymgmt.c
@@ -254,7 +254,7 @@ static int ibmca_keymgmt_rsa_priv_key_from_data(
         goto error;
     }
     rc = ibmca_param_get_bn(provctx, params, OSSL_PKEY_PARAM_RSA_D, d);
-    if (rc == 0)
+    if (rc <= 0)
         goto error;
 
     /* OSSL_PKEY_PARAM_RSA_FACTOR1 */
@@ -264,7 +264,7 @@ static int ibmca_keymgmt_rsa_priv_key_from_data(
         goto error;
     }
     rc = ibmca_param_get_bn(provctx, params, OSSL_PKEY_PARAM_RSA_FACTOR1, p);
-    if (rc == 0)
+    if (rc <= 0)
         goto error;
 
     /* OSSL_PKEY_PARAM_RSA_FACTOR2 */
@@ -274,7 +274,7 @@ static int ibmca_keymgmt_rsa_priv_key_from_data(
         goto error;
     }
     rc = ibmca_param_get_bn(provctx, params, OSSL_PKEY_PARAM_RSA_FACTOR2, q);
-    if (rc == 0)
+    if (rc <= 0)
         goto error;
 
     /* OSSL_PKEY_PARAM_RSA_EXPONENT1 */
@@ -285,7 +285,7 @@ static int ibmca_keymgmt_rsa_priv_key_from_data(
     }
     rc = ibmca_param_get_bn(provctx, params, OSSL_PKEY_PARAM_RSA_EXPONENT1,
                             dp);
-    if (rc == 0)
+    if (rc <= 0)
         goto error;
 
     /* OSSL_PKEY_PARAM_RSA_EXPONENT2 */
@@ -296,7 +296,7 @@ static int ibmca_keymgmt_rsa_priv_key_from_data(
     }
     rc = ibmca_param_get_bn(provctx, params, OSSL_PKEY_PARAM_RSA_EXPONENT2,
                             dq);
-    if (rc == 0)
+    if (rc <= 0)
         goto error;
 
     /* OSSL_PKEY_PARAM_RSA_COEFFICIENT1 */
@@ -307,7 +307,7 @@ static int ibmca_keymgmt_rsa_priv_key_from_data(
     }
     rc = ibmca_param_get_bn(provctx, params, OSSL_PKEY_PARAM_RSA_COEFFICIENT1,
                             qinv);
-    if (rc == 0)
+    if (rc <= 0)
         goto error;
 
     return 1;
@@ -1744,7 +1744,7 @@ int ibmca_keymgmt_rsa_import(void *vkey, int selection,
         if (BN_bn2binpad(p, key->rsa.private.p,
                          ICA_P_LEN(key->rsa.private.key_length)) <= 0) {
             put_error_key(key, IBMCA_ERR_INTERNAL_ERROR,
-                          "BN_bn2binpad failed for private d");
+                          "BN_bn2binpad failed for private p");
             goto out;
         }
         if (BN_bn2binpad(q, key->rsa.private.q,


### PR DESCRIPTION
Update the IBMCA provider code to know newly added parameters and changed behavior that were added to the OpenSSL code base over time. 

Note that most code changes in this PR are only included when compiling against a newer OpenSSL library, i.e. >= OpenSSL 3.1. For compiled against OpenSSL 3.0 the changes should be a no-change.