### PR TITLE
provider: EC signature: Allow OSSL_SIGNATURE_PARAM_NONCE_TYPE to be retrieved

### DIFF
--- a/src/provider/ec_signature.c
+++ b/src/provider/ec_signature.c
@@ -698,6 +698,14 @@ static int ibmca_signature_ec_get_ctx_params(void *vctx,
     if (rc == 0)
        return 0;
 
+#ifdef OSSL_SIGNATURE_PARAM_NONCE_TYPE
+    /* OSSL_SIGNATURE_PARAM_NONCE_TYPE */
+    rc = ibmca_param_build_set_uint(ctx->provctx, NULL, params,
+                                    OSSL_SIGNATURE_PARAM_NONCE_TYPE, 0);
+    if (rc == 0)
+       return 0;
+#endif
+
     return 1;
 }
 
@@ -770,6 +778,9 @@ static const OSSL_PARAM ibmca_signature_ec_gettable_params[] = {
     OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
+#ifdef OSSL_SIGNATURE_PARAM_NONCE_TYPE
+    OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, NULL),
+#endif
     OSSL_PARAM_END
 };
 


### PR DESCRIPTION
OpenSSL now also allows to retrieve parameter OSSL_SIGNATURE_PARAM_NONCE_TYPE, so the IBMCA provider should allow that, too. Always return 0 to indicate that we do not support deterministic signatures.

Related OpenSSL commit: https://github.com/openssl/openssl/commit/1d857945324810f43a302c9d062c617207093387

