### PR TITLE
engine: Enable RSA blinding and offload blinding setup to libica

### DIFF
--- a/src/engine/ibmca_rsa.c
+++ b/src/engine/ibmca_rsa.c
@@ -296,7 +296,12 @@ end:
 
 static int ibmca_rsa_init(RSA * rsa)
 {
-    RSA_blinding_off(rsa);
+    /*
+     * Ensure that the MONT_CTXs for public and private keys are cached.
+     * This enables that ibmca_mod_exp_mont() is also called during
+     * (re-)setup of the RSA blinding factors.
+     */
+    RSA_set_flags(rsa, RSA_FLAG_CACHE_PUBLIC | RSA_FLAG_CACHE_PRIVATE);
 
     return 1;
 }


### PR DESCRIPTION
For whatever reason RSA blinding was disabled for the IBMCA engine. One possible reason is that setting up the blinding factors also requires a mod-expo operation, and this operation does not get offloaded to libica, unless a Montgomery context for the public key (modulus) was setup before.

Do no longer disable blinding, but make sure that a Montgomery contexts for the public and private keys are cached, like it is done without an engine. That way the mod-expo operation used for setting up the blinding context is also offloaded via ibmca_mod_exp().

Note: Due to a bug in OpenSSL code, the offloading of the mod-expo for the blinding setup does currently not work for private decrypt operations, but only for private encrypt (signature create) operations. Once that bug is fixed in OpenSSL, it will also work for private decrypt operations without an additional change in the IBMCA engine.
Related OpenSSL issue: https://github.com/openssl/openssl/issues/20579