### PR TITLE
engine: Only register those algos specified with default_algorithms

### DIFF
--- a/src/engine/e_ibmca.c
+++ b/src/engine/e_ibmca.c
@@ -642,6 +642,9 @@ static int set_supported_meths(ENGINE *e)
         if (!ENGINE_set_pkey_meths(e, ibmca_engine_pkey_meths))
             goto out;
 
+    if (!ENGINE_set_flags(e, ENGINE_FLAGS_NO_REGISTER_ALL))
+        goto out;
+
     rc = 1;
 out:
     free(pmech_list);


### PR DESCRIPTION
As part of OpenSSl initialization, the engine(s) configured in the OpenSSL config file are loaded, and its algorithms (methods) are registered according to the default_algorithms setting.

However, later during initialization, ENGINE_register_all_complete() is called which unconditionally registered all algorithms (methods) of the loaded engines again, unless the engine flag ENGINE_FLAGS_NO_REGISTER_ALL is set.

Set the ENGINE_FLAGS_NO_REGISTER_ALL flag during IBMCA engine initialization to avoid unconditional registration of all algorithms. We only want to register thise algorithms specified in the default_algorithms configuration setting.

Note that if the default_algorithms setting is omitted in the OpenSSL config file, then no algorithms will be registered.