### PR TITLE
provider: Default debug directory to /tmp but make it configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AM_INIT_AUTOMAKE([foreign])
 
 AC_PATH_PROG([CHMOD], [chmod], [/bin/chmod])
 
-logdir=$localstatedir/log/ibmca
+logdir=/tmp
 AC_SUBST(logdir)
 
 # Cmdline arguments.

--- a/src/provider/Makefile.am
+++ b/src/provider/Makefile.am
@@ -25,7 +25,3 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = doc
 
 noinst_SCRIPTS = ibmca-provider-opensslconfig
-
-install-data-hook:
-	$(MKDIR_P) $(DESTDIR)$(logdir)
-	$(CHMOD) 0777 $(DESTDIR)$(logdir)

--- a/src/provider/doc/ibmca-provider.man
+++ b/src/provider/doc/ibmca-provider.man
@@ -94,13 +94,25 @@ provider if you are on an IBM z15 or later. This would actually make it slower.
 .IP "debug = yes | no | stderr"
 .RS
 Enables debug output for the IBMCA provider. If this option is not specified,
-no debuging output is produced. If \fBdebug = stderr\fP is specified,
+no debugging output is produced. If \fBdebug = stderr\fP is specified,
 debugging messages are printed to stderr. Otherwise the debug output is written
-into a trace file in \fB[/usr/local]/var/log/ibmca/trace-<provider-name>.<pid>\fP,
-where <provider-name> is the name of the IBMCA provider from the identity
-option, and <pid> is the process ID of the current process. You can also
-enable debugging by setting the environment variable \fBIBMCA_DEBUG\fP to
-\fBon\fP or \fBstderr\fP.
+into a trace file in \fB<debug-path>/trace-<provider-name>.<pid>\fP,
+where <debug-path> is the path name of a directory to where the debug files are
+written (default: \fB/tmp\fP), <provider-name> is the name of the IBMCA provider
+from the identity option, and <pid> is the process ID of the current process.
+You can also enable debugging by setting the environment variable
+\fBIBMCA_DEBUG\fP to \fBon\fP or \fBstderr\fP.
+.RE
+.PP
+.IP "debug-path = /dir/to/debug/directory"
+.RS
+Sets the directory path to where debug files are written when debug is enabled
+via \fBdebug = yes\fP or via environment variable \fBIBMCA_DEBUG=on\fP.
+You can also set the debug path by setting the environment variable
+\fBIBMCA_DEBUG_PATH\fP to the directory path. It must be ensured that the user
+under which the application that uses the IBMCA provider runs has write access
+to that directory. If this option is not specified, the default debug path is
+\fB/tmp\fP.
 .RE
 .PP
 .IP "fips = yes | no"
@@ -153,8 +165,18 @@ If
 .B $IBMCA_DEBUG
 is set to \fBstderr\fP debug output to stderr for the IBMCA provider is enabled.
 If it is set to \fBon\fP the debug output is written into a trace file in
-\fB[/usr/local]/var/log/ibmca/trace-<provider-name>.<pid>\fP, where <pid> is
-the process ID of the current process.
+\fB<debug-path>/trace-<provider-name>.<pid>\fP, where <debug-path> is the path
+name of a directory to where the debug files are written (default: \fB/tmp\fP),
+<provider-name> is the name of the IBMCA provider from the identity option,
+and <pid> is the process ID of the current process.
+.PP
+.TP
+.BR IBMCA_DEBUG_PATH
+Sets the directory path to where debug files are written when debug is enabled
+via \fBdebug = yes\fP configuration option or via environment variable
+\fBIBMCA_DEBUG=on\fP. It must be ensured that the user under which the
+application that uses the IBMCA provider runs has write access to that
+directory.
 .PP
 .SH SEE ALSO
 .B provider(1)

--- a/src/provider/p_ibmca.h
+++ b/src/provider/p_ibmca.h
@@ -27,9 +27,11 @@
 
 /* Environment variable name to enable debug */
 #define IBMCA_DEBUG_ENVVAR          "IBMCA_DEBUG"
+#define IBMCA_DEBUG_PATH_ENVVAR     "IBMCA_DEBUG_PATH"
 
 /* IBMCA provider configuration key words */
 #define IBMCA_CONF_DEBUG            "debug"
+#define IBMCA_CONF_DEBUG_PATH       "debug-path"
 #define IBMCA_CONF_ALGORITHMS       "algorithms"
 #define IBMCA_CONF_FIPS             "fips"
 #define IBMCA_CONF_FALLBACK_PROPS   "fallback-properties"
@@ -64,6 +66,7 @@ struct ibmca_prov_ctx {
     OSSL_FUNC_CRYPTO_secure_clear_free_fn *c_secure_clear_free;
     OSSL_FUNC_OPENSSL_cleanse_fn *c_cleanse;
     bool debug;
+    const char *debug_path;
     FILE *debug_file;
     pid_t debug_pid;
     pthread_mutex_t debug_mutex;

--- a/test/provider/openssl-test.cnf
+++ b/test/provider/openssl-test.cnf
@@ -16,6 +16,7 @@ identity = ibmca
 module = ibmca-provider.so
 activate = 1
 #debug = yes
+#debug-path = /dir/to/debug/directory
 #fips=yes
 #algorithms = RSA,EC,DH
 algorithms = ALL


### PR DESCRIPTION
The IBMCA provider debug logs were written to the /var/log/ibmca/ directory, but this required that directory to be world-writable, because we don't know under which user an application runs that uses the provider. A world-writable directory under /var has security implications and should be avoided.

Change the default log directory to /tmp which is world-writable anyway. Additionally the log directory can now be configured via the 'debug-path' option in the IBMCA provider section of the OpenSSL config file, or via environment variable 'IBMCA_DEBUG_PATH'.

Closes: https://github.com/opencryptoki/openssl-ibmca/issues/107