### PR TITLE
engine: Enable external AES-GCM IV when libica is in FIPS mode

### DIFF
--- a/src/engine/e_ibmca.c
+++ b/src/engine/e_ibmca.c
@@ -103,6 +103,8 @@ ica_aes_gcm_intermediate_t      p_ica_aes_gcm_intermediate;
 ica_aes_gcm_last_t              p_ica_aes_gcm_last;
 #endif
 ica_cleanup_t                   p_ica_cleanup;
+ica_allow_external_gcm_iv_in_fips_mode_t
+                                p_ica_allow_external_gcm_iv_in_fips_mode;
 
 /* save libcrypto's default ec methods */
 #ifndef NO_EC
@@ -825,7 +827,15 @@ static int ibmca_init(ENGINE *e)
     BIND(ibmca_dso, ica_ed448_ctx_del);
 
     /* ica_cleanup is not always present and only needed for newer libraries */
-    p_ica_cleanup = (ica_cleanup_t)dlsym(ibmca_dso, "ica_cleanup");
+    BIND(ibmca_dso, ica_cleanup);
+
+    /*
+     * Allow external AES-GCM IV when libica runs in FIPS mode.
+     * ica_allow_external_gcm_iv_in_fips_mode() is not always present and only
+     * available with newer libraries.
+     */
+    if (BIND(ibmca_dso, ica_allow_external_gcm_iv_in_fips_mode))
+        p_ica_allow_external_gcm_iv_in_fips_mode(1);
 
     /* disable fallbacks on Libica */
     if (BIND(ibmca_dso, ica_set_fallback_mode))

--- a/src/engine/ibmca.h
+++ b/src/engine/ibmca.h
@@ -617,6 +617,7 @@ typedef
 int (*ica_ed448_ctx_del_t)(ICA_ED448_CTX **ctx);
 
 typedef void (*ica_cleanup_t)(void);
+typedef void (*ica_allow_external_gcm_iv_in_fips_mode_t)(int allow);
 
 /* entry points into libica, filled out at DSO load time */
 extern ica_get_functionlist_t           p_ica_get_functionlist;


### PR DESCRIPTION
When the system is in FIPS mode, newer libica versions may prevent AES-GCM from being used with an external IV. FIPS requires that the AES-GCM IV is created libica internally via an approved random source.

The IBMCA engine can not support the internal generation of the AES-GCM IV, because the engine API for AES-GCM does not allow this. Applications using OpenSSL to perform AES-GCM (e.g. the TLS protocol) may require to provide an external IV.

Enable the use of external AES-GCM IVs for libica, if the used libica library supports this. Newer libica versions support to allow external AES-GCM IVs via function ica_allow_external_gcm_iv_in_fips_mode().