### PR TITLE
test/provider: Do not link against libica use dlopen instead

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,8 @@ AC_ARG_WITH([provider-libica-full],
 	[])
 AM_CONDITIONAL([PROVIDER_FULL_LIBICA], [test "x$useproviderfulllibica" = xyes])
 
+AC_SUBST(libicaversion, "$libicaversion")
+
 # If compiled against OpenSSL 3.0 or later, build the provider unless
 # explicitely disabled. 
 # If build against OpenSSL 1.1.1, we can not build the provider.

--- a/test/provider/Makefile.am
+++ b/test/provider/Makefile.am
@@ -24,24 +24,27 @@ TESTS = \
 check_PROGRAMS = rsakey eckey dhkey threadtest
 
 dhkey_SOURCES = dhkey.c
+dhkey_LDADD = -lcrypto -ldl
 if PROVIDER_FULL_LIBICA
-dhkey_LDADD = -lcrypto -lica
+dhkey_CFLAGS = -DLIBICA_NAME=\"libica.so.@libicaversion@\"
 else
-dhkey_LDADD = -lcrypto -lica-cex
+dhkey_CFLAGS = -DLIBICA_NAME=\"libica-cex.so.@libicaversion@\"
 endif
 
 eckey_SOURCES = eckey.c
+eckey_LDADD = -lcrypto -ldl
 if PROVIDER_FULL_LIBICA
-eckey_LDADD = -lcrypto -lica
+eckey_CFLAGS = -DLIBICA_NAME=\"libica.so.@libicaversion@\"
 else
-eckey_LDADD = -lcrypto -lica-cex
+eckey_CFLAGS = -DLIBICA_NAME=\"libica-cex.so.@libicaversion@\"
 endif
 
 rsakey_SOURCES = rsakey.c
+rsakey_LDADD = -lcrypto -ldl
 if PROVIDER_FULL_LIBICA
-rsakey_LDADD = -lcrypto -lica
+rsakey_CFLAGS = -DLIBICA_NAME=\"libica.so.@libicaversion@\"
 else
-rsakey_LDADD = -lcrypto -lica-cex
+rsakey_CFLAGS = -DLIBICA_NAME=\"libica-cex.so.@libicaversion@\"
 endif
 
 threadtest_SOURCES = threadtest.c

--- a/test/provider/dhkey.c
+++ b/test/provider/dhkey.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <dlfcn.h>
 
 #include <openssl/conf.h>
 #include <openssl/evp.h>
@@ -355,13 +356,32 @@ static const unsigned int required_ica_mechs[] = { RSA_ME };
 static const unsigned int required_ica_mechs_len =
                         sizeof(required_ica_mechs) / sizeof(unsigned int);
 
+typedef unsigned int (*ica_get_functionlist_t)(libica_func_list_element *,
+                                               unsigned int *);
+
 int check_libica()
 {
     unsigned int mech_len, i, k, found = 0;
     libica_func_list_element *mech_list = NULL;
+    void *ibmca_dso;
+    ica_get_functionlist_t p_ica_get_functionlist;
     int rc;
 
-    rc = ica_get_functionlist(NULL, &mech_len);
+    ibmca_dso = dlopen(LIBICA_NAME, RTLD_NOW);
+    if (ibmca_dso == NULL) {
+        fprintf(stderr, "Failed to load libica '%s'!\n", LIBICA_NAME);
+        return 77;
+    }
+
+    p_ica_get_functionlist =
+            (ica_get_functionlist_t)dlsym(ibmca_dso, "ica_get_functionlist");
+    if (p_ica_get_functionlist == NULL) {
+        fprintf(stderr, "Failed to get ica_get_functionlist from '%s'!\n",
+                LIBICA_NAME);
+        return 77;
+    }
+
+    rc = p_ica_get_functionlist(NULL, &mech_len);
     if (rc != 0) {
         fprintf(stderr, "Failed to get function list from libica!\n");
         return 77;
@@ -373,7 +393,7 @@ int check_libica()
         return 77;
     }
 
-    rc = ica_get_functionlist(mech_list, &mech_len);
+    rc = p_ica_get_functionlist(mech_list, &mech_len);
     if (rc != 0) {
         fprintf(stderr, "Failed to get function list from libica!\n");
         free(mech_list);

--- a/test/provider/eckey.c
+++ b/test/provider/eckey.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <dlfcn.h>
 
 #include <openssl/conf.h>
 #include <openssl/evp.h>
@@ -788,13 +789,32 @@ static const unsigned int required_ica_mechs[] = { EC_DH, EC_DSA_SIGN,
 static const unsigned int required_ica_mechs_len =
                         sizeof(required_ica_mechs) / sizeof(unsigned int);
 
+typedef unsigned int (*ica_get_functionlist_t)(libica_func_list_element *,
+                                               unsigned int *);
+
 int check_libica()
 {
     unsigned int mech_len, i, k, found = 0;
     libica_func_list_element *mech_list = NULL;
+    void *ibmca_dso;
+    ica_get_functionlist_t p_ica_get_functionlist;
     int rc;
 
-    rc = ica_get_functionlist(NULL, &mech_len);
+    ibmca_dso = dlopen(LIBICA_NAME, RTLD_NOW);
+    if (ibmca_dso == NULL) {
+        fprintf(stderr, "Failed to load libica '%s'!\n", LIBICA_NAME);
+        return 77;
+    }
+
+    p_ica_get_functionlist =
+            (ica_get_functionlist_t)dlsym(ibmca_dso, "ica_get_functionlist");
+    if (p_ica_get_functionlist == NULL) {
+        fprintf(stderr, "Failed to get ica_get_functionlist from '%s'!\n",
+                LIBICA_NAME);
+        return 77;
+    }
+
+    rc = p_ica_get_functionlist(NULL, &mech_len);
     if (rc != 0) {
         fprintf(stderr, "Failed to get function list from libica!\n");
         return 77;
@@ -806,7 +826,7 @@ int check_libica()
         return 77;
     }
 
-    rc = ica_get_functionlist(mech_list, &mech_len);
+    rc = p_ica_get_functionlist(mech_list, &mech_len);
     if (rc != 0) {
         fprintf(stderr, "Failed to get function list from libica!\n");
         free(mech_list);


### PR DESCRIPTION
When an application links against libica (via -lica), then the libica library constructor runs before the program's main function. Libica's library constructor does initialize OpenSSL and thus parses the config file.

However, the test programs set up some OpenSSL configuration related environment variables within function check_libica() called from the the main function. If libica has already initialized OpenSSL prior to that, OpenSSL won't initialize again, and thus these environment variables have no effect.

Dynamically load libica (via dlopen) only after setting the environment variables.