### PR TITLE
test/provider: Explicitly initialize OpenSSL after setting env vars

### DIFF
--- a/test/provider/dhkey.c
+++ b/test/provider/dhkey.c
@@ -461,6 +461,8 @@ int main(int argc, char **argv)
         return 77;
     }
 
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     ret = check_libica();
     if (ret != 0)
         return ret;

--- a/test/provider/eckey.c
+++ b/test/provider/eckey.c
@@ -895,6 +895,8 @@ int main(int argc, char **argv)
         return 77;
     }
 
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     ret = check_libica();
     if (ret != 0)
         return ret;

--- a/test/provider/rsakey.c
+++ b/test/provider/rsakey.c
@@ -839,6 +839,8 @@ int main(int argc, char **argv)
         return 77;
     }
 
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     ret = check_libica();
     if (ret != 0)
         return ret;


### PR DESCRIPTION
When running with a libica version without commit https://github.com/opencryptoki/libica/commit/42e197f61b298c6e6992b080c1923e7e85edea5a it is necessary to explicitly initialize OpenSSL before loading libica. Because otherwise libica's library constructor will initialize OpenSSL the first time, which in turn will load the IBMCA provider, and it will fall into the same problem as fixed by above libica commit, i.e. the provider won't be able to get the supported algorithms from libica an thus will not register any algorithms.