### PR TITLE
Fix compiler error for undefined ERR_pop_to_mark

### DIFF
--- a/src/engine/ibmca_ec.c
+++ b/src/engine/ibmca_ec.c
@@ -17,6 +17,7 @@
 
 #include <stdlib.h>
 #include <pthread.h>
+#include <openssl/err.h>
 #include "ibmca.h"
 #include "e_ibmca_err.h"
 


### PR DESCRIPTION
    ibmca_ec.c:342:5: error: implicit declaration of function
           'ERR_pop_to_mark' [-Wimplicit-function-declaration]
      342 |     ERR_pop_to_mark();
          |     ^~~~~~~~~~~~~~~

Fixes: 6bc53d814762b24045bfd5bb6003949a163fa58b