### PR TITLE
Provider currency updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,11 @@ else
 	CFLAGS="$CFLAGS -O2 -Wall"
 fi
 
+AC_ARG_ENABLE([sanitizer],
+		AS_HELP_STRING([--enable-sanitizer],[enable sanitizer build (may not work in all environments) @<:@default=no@:>@]),
+		[],
+		[enable_sanitizer=no])
+
 AC_ARG_ENABLE([engine],
 		[AS_HELP_STRING([--enable-engine], [build IBMCA engine (OpenSSL 1.1.1, default is yes)])],
 		[if test "x$enableval" = "xyes" ; then
@@ -151,6 +156,19 @@ if test "x$enable_provider" = xyes; then
 fi
 
 AC_CHECK_DECLS([ica_cleanup],,,[#include <ica_api.h>])
+
+if test "x$enable_sanitizer" = "xyes"; then
+	AC_CHECK_LIB([asan], [strcpy], [LDFLAGS="-lasan $LDFLAGS"],
+			[AC_MSG_ERROR(['libasan' library is missing on your system. Please install 'libasan'.])])
+	AC_CHECK_LIB([ubsan], [strcpy], [LDFLAGS="-lubsan $LDFLAGS"],
+			[AC_MSG_ERROR(['libubsan' library is missing on your system. Please install 'libubsan'.])])
+	if test "x$enable_debug" = "xyes"; then
+		CFLAGS="$CFLAGS -O2 -g3 -DDEBUG"
+	fi
+	CFLAGS="$CFLAGS -fstack-protector-all -fsanitize=address,signed-integer-overflow,undefined -Wformat -Wformat-security -Werror=format-security -Warray-bounds -Werror=array-bounds -D_FORTIFY_SOURCE=2"
+	AC_DEFINE([WITH_SANITIZER])
+	AC_MSG_RESULT([*** Enabling sanitizer at user request ***])
+fi
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/provider/dh_keyexch.c
+++ b/src/provider/dh_keyexch.c
@@ -685,6 +685,13 @@ static int ibmca_keyexch_dh_set_ctx_params(void *vctx,
             return 0;
         }
 
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+            put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                             "XOF Digest '%s' is not allowed", name);
+            EVP_MD_free(md);
+            return 0;
+        }
+
         if (ctx->dh.derive.kdf_md != NULL)
             EVP_MD_free(ctx->dh.derive.kdf_md);
         ctx->dh.derive.kdf_md = md;

--- a/src/provider/ec_keyexch.c
+++ b/src/provider/ec_keyexch.c
@@ -636,6 +636,13 @@ static int ibmca_keyexch_ec_set_ctx_params(void *vctx,
             return 0;
         }
 
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+            put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                             "XOF Digest '%s' is not allowed", name);
+            EVP_MD_free(md);
+            return 0;
+        }
+
         if (ctx->ec.derive.kdf_md != NULL)
             EVP_MD_free(ctx->ec.derive.kdf_md);
         ctx->ec.derive.kdf_md = md;

--- a/src/provider/ec_keymgmt.c
+++ b/src/provider/ec_keymgmt.c
@@ -898,6 +898,12 @@ static void ibmca_keymgmt_ec_gen_free_cb(struct ibmca_op_ctx *ctx)
 
     ctx->ec.gen.curve_nid = NID_undef;
     ctx->ec.gen.format = POINT_CONVERSION_UNCOMPRESSED;
+
+    if (ctx->ec.gen.dhkem_ikm != NULL)
+        P_CLEAR_FREE(ctx->provctx, ctx->ec.gen.dhkem_ikm,
+                    ctx->ec.gen.dhkem_ikmlen);
+    ctx->ec.gen.dhkem_ikm = NULL;
+    ctx->ec.gen.dhkem_ikmlen = 0;
 }
 
 static int ibmca_keymgmt_ec_gen_dup_cb(const struct ibmca_op_ctx *ctx,
@@ -910,6 +916,23 @@ static int ibmca_keymgmt_ec_gen_dup_cb(const struct ibmca_op_ctx *ctx,
 
     new_ctx->ec.gen.curve_nid = ctx->ec.gen.curve_nid;
     new_ctx->ec.gen.format = ctx->ec.gen.format;
+
+    if (ctx->ec.gen.dhkem_ikm != NULL)
+        P_CLEAR_FREE(ctx->provctx, ctx->ec.gen.dhkem_ikm,
+                    ctx->ec.gen.dhkem_ikmlen);
+    new_ctx->ec.gen.dhkem_ikm = NULL;
+    new_ctx->ec.gen.dhkem_ikmlen = 0;
+    if (ctx->ec.gen.dhkem_ikm != NULL) {
+        new_ctx->ec.gen.dhkem_ikm = P_MEMDUP(ctx->provctx,
+                                             ctx->ec.gen.dhkem_ikm,
+                                             ctx->ec.gen.dhkem_ikmlen);
+        if (new_ctx->ec.gen.dhkem_ikm == NULL) {
+            put_error_op_ctx(ctx, IBMCA_ERR_MALLOC_FAILED,
+                          "Failed to duplicate DHKEM-IKM buffer");
+            return 0;
+        }
+        new_ctx->ec.gen.dhkem_ikmlen = ctx->ec.gen.dhkem_ikmlen;
+    }
 
     return 1;
 }
@@ -996,6 +1019,10 @@ static int ibmca_keymgmt_ec_gen_set_params(void *vgenctx,
     const char *name;
     EC_GROUP *group;
     int rc, value;
+#ifdef OSSL_PKEY_PARAM_DHKEM_IKM
+    unsigned char *ptr = NULL;
+    size_t len = 0;
+#endif
 
     if (genctx == NULL)
         return 0;
@@ -1081,11 +1108,17 @@ static int ibmca_keymgmt_ec_gen_set_params(void *vgenctx,
     }
 
 #ifdef OSSL_PKEY_PARAM_DHKEM_IKM
-    if (OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DHKEM_IKM) != NULL) {
-        put_error_op_ctx(genctx, IBMCA_ERR_INVALID_PARAM,
-                         "EC parameter '%s' is not supported",
-                         OSSL_PKEY_PARAM_DHKEM_IKM);
+    rc = ibmca_param_get_octet_string(genctx->provctx, params,
+                                      OSSL_PKEY_PARAM_DHKEM_IKM,
+                                      (void **)&ptr, &len);
+    if (rc == 0)
         return 0;
+    if (rc > 0) {
+        if (genctx->ec.gen.dhkem_ikm != NULL)
+            P_CLEAR_FREE(genctx->provctx, genctx->ec.gen.dhkem_ikm,
+                         genctx->ec.gen.dhkem_ikmlen);
+        genctx->ec.gen.dhkem_ikm = ptr;
+        genctx->ec.gen.dhkem_ikmlen = len;
     }
 #endif
 
@@ -1125,6 +1158,9 @@ static int ibmca_keymgmt_ec_gen_fallback(struct ibmca_op_ctx *genctx,
     struct ibmca_keygen_cb_data cbdata;
     EVP_PKEY_CTX *pctx = NULL;
     EVP_PKEY *pkey = NULL;
+#ifdef OSSL_PKEY_PARAM_DHKEM_IKM
+    OSSL_PARAM params[2];
+#endif
     int rc = 0;
 
     ibmca_debug_op_ctx(genctx, "genctx: %p", genctx);
@@ -1153,6 +1189,22 @@ static int ibmca_keymgmt_ec_gen_fallback(struct ibmca_op_ctx *genctx,
                      "EVP_PKEY_CTX_set_ec_paramgen_curve_nid failed");
         goto out;
     }
+
+#ifdef OSSL_PKEY_PARAM_DHKEM_IKM
+    if (genctx->ec.gen.dhkem_ikm != NULL && genctx->ec.gen.dhkem_ikmlen > 0) {
+        params[0] = OSSL_PARAM_construct_octet_string(
+                                                OSSL_PKEY_PARAM_DHKEM_IKM,
+                                                genctx->ec.gen.dhkem_ikm,
+                                                genctx->ec.gen.dhkem_ikmlen);
+        params[1] = OSSL_PARAM_construct_end();
+
+        if (EVP_PKEY_CTX_set_params(pctx, params) != 1) {
+            put_error_op_ctx(genctx, IBMCA_ERR_INTERNAL_ERROR,
+                             "EVP_PKEY_CTX_set_params failed");
+            goto out;
+        }
+    }
+#endif
 
     if (osslcb != NULL) {
         cbdata.osslcb = osslcb;
@@ -1236,6 +1288,14 @@ static void *ibmca_keymgmt_ec_gen(void *vgenctx, OSSL_CALLBACK *osslcb,
 
     if ((genctx->ec.gen.selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
         goto out;
+
+    ibmca_debug_op_ctx(genctx, "dhkem_ikm: %p", genctx->ec.gen.dhkem_ikm);
+    ibmca_debug_op_ctx(genctx, "dhkem_ikmlen: %u", genctx->ec.gen.dhkem_ikmlen);
+
+    if (genctx->ec.gen.dhkem_ikm != NULL && genctx->ec.gen.dhkem_ikmlen > 0) {
+        ibmca_debug_op_ctx(genctx, "DHKEM-IKM is set, force use of fallback");
+        fallback = true;
+    }
 
     key->ec.key = ica_ec_key_new(key->ec.curve_nid, &privlen);
     if (key->ec.key == NULL || key->ec.prime_size != privlen) {

--- a/src/provider/ec_signature.c
+++ b/src/provider/ec_signature.c
@@ -212,6 +212,13 @@ static int ibmca_signature_ec_set_md(struct ibmca_op_ctx *ctx,
         return 0;
     }
 
+    if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+        put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                         "XOF Digest '%s' is not allowed", mdname);
+        EVP_MD_free(md);
+        return 0;
+    }
+
     if (ctx->ec.signature.md != NULL)
         EVP_MD_free(ctx->ec.signature.md);
 

--- a/src/provider/p_context.c
+++ b/src/provider/p_context.c
@@ -254,7 +254,13 @@ int ibmca_digest_signverify_update(struct ibmca_op_ctx *ctx, EVP_MD_CTX *md_ctx,
 
     if (ctx->key == NULL || md_ctx == NULL ||
         (ctx->operation != EVP_PKEY_OP_SIGNCTX &&
+#ifdef EVP_PKEY_OP_SIGNMSG
+         ctx->operation != EVP_PKEY_OP_VERIFYCTX &&
+         ctx->operation != EVP_PKEY_OP_SIGNMSG &&
+         ctx->operation != EVP_PKEY_OP_VERIFYMSG)) {
+#else
          ctx->operation != EVP_PKEY_OP_VERIFYCTX)) {
+#endif
         put_error_op_ctx(ctx, IBMCA_ERR_INTERNAL_ERROR,
                          "sign operation not initialized");
         return 0;
@@ -283,7 +289,12 @@ int ibmca_digest_sign_final(struct ibmca_op_ctx *ctx, EVP_MD_CTX *md_ctx,
                        ctx, ctx->key, sigsize);
 
     if (ctx->key == NULL || md_ctx == NULL ||
+#ifdef EVP_PKEY_OP_SIGNMSG
+        (ctx->operation != EVP_PKEY_OP_SIGNCTX &&
+         ctx->operation != EVP_PKEY_OP_SIGNMSG)) {
+#else
         ctx->operation != EVP_PKEY_OP_SIGNCTX) {
+#endif
         put_error_op_ctx(ctx, IBMCA_ERR_INTERNAL_ERROR,
                          "sign operation not initialized");
         return 0;
@@ -321,7 +332,12 @@ int ibmca_digest_verify_final(struct ibmca_op_ctx *ctx, EVP_MD_CTX *md_ctx,
                        ctx, ctx->key, siglen);
 
     if (ctx->key == NULL || md_ctx == NULL ||
+#ifdef EVP_PKEY_OP_SIGNMSG
+        (ctx->operation != EVP_PKEY_OP_VERIFYCTX &&
+         ctx->operation != EVP_PKEY_OP_VERIFYMSG)) {
+#else
         ctx->operation != EVP_PKEY_OP_VERIFYCTX) {
+#endif
         put_error_op_ctx(ctx, IBMCA_ERR_INTERNAL_ERROR,
                          "verify operation not initialized");
         return 0;

--- a/src/provider/p_ibmca.c
+++ b/src/provider/p_ibmca.c
@@ -879,7 +879,7 @@ static int ibmca_config_debug(struct ibmca_prov_ctx *provctx,
     if (provctx->debug == true) {
         provctx->debug_pid = getpid();
 
-        strncpy(prov_name, provctx->name, sizeof(prov_name));
+        strncpy(prov_name, provctx->name, sizeof(prov_name) - 1);
         prov_name[sizeof(prov_name) - 1] = '\0';
         while ((p = strchr(prov_name, '/')) != NULL)
             *p = '_';

--- a/src/provider/p_ibmca.h
+++ b/src/provider/p_ibmca.h
@@ -242,6 +242,8 @@ struct ibmca_op_ctx {
                 size_t md_size;
                 EVP_MD_CTX *md_ctx;
                 unsigned int nonce_type;
+                unsigned char *signature;
+                size_t signature_len;
             } signature; /* For operation EVP_PKEY_OP_SIGN/VERIFY */
             struct {
                 struct ibmca_key *peer_key;

--- a/src/provider/p_ibmca.h
+++ b/src/provider/p_ibmca.h
@@ -226,6 +226,8 @@ struct ibmca_op_ctx {
                 int saltlen;
                 struct ibmca_pss_params pss;
                 EVP_MD_CTX *md_ctx;
+                unsigned char *signature;
+                size_t signature_len;
             } signature; /* For operation EVP_PKEY_OP_SIGN/VERIFY */
         } rsa; /* For type EVP_PKEY_RSA and EVP_PKEY_RSA_PSS */
         union {

--- a/src/provider/p_ibmca.h
+++ b/src/provider/p_ibmca.h
@@ -239,6 +239,7 @@ struct ibmca_op_ctx {
                 bool set_md_allowed;
                 size_t md_size;
                 EVP_MD_CTX *md_ctx;
+                unsigned int nonce_type;
             } signature; /* For operation EVP_PKEY_OP_SIGN/VERIFY */
             struct {
                 struct ibmca_key *peer_key;

--- a/src/provider/p_ibmca.h
+++ b/src/provider/p_ibmca.h
@@ -233,6 +233,8 @@ struct ibmca_op_ctx {
                 int selection;
                 int curve_nid;
                 point_conversion_form_t format;
+                unsigned char *dhkem_ikm;
+                size_t dhkem_ikmlen;
             } gen; /* For operation EVP_PKEY_OP_KEYGEN */
             struct {
                 EVP_MD *md;

--- a/src/provider/rsa_asym_cipher.c
+++ b/src/provider/rsa_asym_cipher.c
@@ -303,6 +303,15 @@ static int ibmca_asym_cipher_rsa_set_ctx_params(void *vctx,
                                   "Failed to fetch default OAEP digest");
                     return 0;
                 }
+
+                if ((EVP_MD_get_flags(ctx->rsa.cipher.oaep_md) &
+                                                        EVP_MD_FLAG_XOF) != 0) {
+                    put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                                     "XOF Digest '%s' is not allowed", name);
+                    EVP_MD_free(ctx->rsa.cipher.oaep_md);
+                    ctx->rsa.cipher.oaep_md = NULL;
+                    return 0;
+                }
             }
             break;
         case RSA_PKCS1_PSS_PADDING: /* PSS is for signatures only */
@@ -337,6 +346,15 @@ static int ibmca_asym_cipher_rsa_set_ctx_params(void *vctx,
                               "Invalid RSA OAEP digest: '%s'", name);
             return 0;
         }
+
+        if ((EVP_MD_get_flags(ctx->rsa.cipher.oaep_md) &
+                                                EVP_MD_FLAG_XOF) != 0) {
+            put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                             "XOF Digest '%s' is not allowed", name);
+            EVP_MD_free(ctx->rsa.cipher.oaep_md);
+            ctx->rsa.cipher.oaep_md = NULL;
+            return 0;
+        }
     }
 
     /* OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST_PROPS */
@@ -359,6 +377,15 @@ static int ibmca_asym_cipher_rsa_set_ctx_params(void *vctx,
         if (ctx->rsa.cipher.mgf1_md == NULL) {
             put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
                               "Invalid RSA MGF1 digest: '%s'", name);
+            return 0;
+        }
+
+        if ((EVP_MD_get_flags(ctx->rsa.cipher.mgf1_md) &
+                                                EVP_MD_FLAG_XOF) != 0) {
+            put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                             "XOF Digest '%s' is not allowed", name);
+            EVP_MD_free(ctx->rsa.cipher.mgf1_md);
+            ctx->rsa.cipher.mgf1_md = NULL;
             return 0;
         }
     }

--- a/src/provider/rsa_keymgmt.c
+++ b/src/provider/rsa_keymgmt.c
@@ -106,6 +106,13 @@ static int ibmca_keymgmt_rsa_pss_parms_from_data(
             return 0;
         }
 
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+            put_error_ctx(provctx, IBMCA_ERR_INVALID_PARAM,
+                          "XOF Digest '%s' is not allowed", name);
+            EVP_MD_free(md);
+            return 0;
+        }
+
         pss->digest_nid = EVP_MD_get_type(md);
         EVP_MD_free(md);
         pss->restricted = true;
@@ -139,6 +146,13 @@ static int ibmca_keymgmt_rsa_pss_parms_from_data(
             put_error_ctx(provctx, IBMCA_ERR_INVALID_PARAM,
                           "RSA PSS '%s'='%s' could not be fetched",
                           OSSL_PKEY_PARAM_RSA_MGF1_DIGEST, name);
+            return 0;
+        }
+
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+            put_error_ctx(provctx, IBMCA_ERR_INVALID_PARAM,
+                          "XOF Digest '%s' is not allowed", name);
+            EVP_MD_free(md);
             return 0;
         }
 

--- a/src/provider/rsa_signature.c
+++ b/src/provider/rsa_signature.c
@@ -228,6 +228,13 @@ static int ibmca_signature_rsa_set_md(struct ibmca_op_ctx *ctx,
         return 0;
     }
 
+    if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+        put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                         "XOF Digest '%s' is not allowed", mdname);
+        EVP_MD_free(md);
+        return 0;
+    }
+
     if (ctx->key->type == EVP_PKEY_RSA_PSS &&
         ctx->rsa.signature.pss.restricted &&
         EVP_MD_get_type(md) != ctx->rsa.signature.pss.digest_nid) {
@@ -261,6 +268,13 @@ static int ibmca_signature_rsa_set_mgf1_md(struct ibmca_op_ctx *ctx,
     if (md == NULL) {
         put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
                          "Digest '%s' could not be fetched", mdname);
+        return 0;
+    }
+
+    if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+        put_error_op_ctx(ctx, IBMCA_ERR_INVALID_PARAM,
+                         "XOF Digest '%s' is not allowed", mdname);
+        EVP_MD_free(md);
         return 0;
     }
 

--- a/test/engine/enginectrl.c
+++ b/test/engine/enginectrl.c
@@ -30,9 +30,12 @@ void setup(void)
 #endif
 }
 
+typedef void (*ica_cleanup_t) (void);
+
 int initwithlib(ENGINE *e, const char *lib, int checkexists, int expectedinitval)
 {
     void *hdl;
+    void (*ica_cleanup)(void);
 
     if (checkexists) {
         hdl = dlopen(lib, RTLD_LAZY);
@@ -40,6 +43,9 @@ int initwithlib(ENGINE *e, const char *lib, int checkexists, int expectedinitval
             fprintf(stderr, "Skipping initialization with non-existent library \"%s\"\n", lib);
             return 1;
         }
+        *(void **)(&ica_cleanup) = dlsym(hdl, "ica_cleanup");
+        if (ica_cleanup != NULL)
+            ica_cleanup();
         dlclose(hdl);
     }
     if (ENGINE_ctrl_cmd_string(e, "libica", lib, 0) != 1) {

--- a/test/engine/threadtest.c
+++ b/test/engine/threadtest.c
@@ -145,6 +145,7 @@ int main(int argc, char **argv)
 
     if (setup() != 1) {
         fprintf(stderr, "Failed to set up test.  Skipping...\n");
+        free(threads);
         return 77;
     }
     
@@ -170,5 +171,6 @@ int main(int argc, char **argv)
             }
         }
     }
+    free(threads);
     return errors ? 99 : 0;
 }

--- a/test/provider/eckey.c
+++ b/test/provider/eckey.c
@@ -32,7 +32,7 @@
 
 #define UNUSED(var)                             ((void)(var))
 
-void setup(void)
+static void setup(void)
 {
     OPENSSL_load_builtin_modules();
 
@@ -41,28 +41,53 @@ void setup(void)
                            CONF_MFLAGS_IGNORE_MISSING_FILE);
 }
 
-int check_eckey(int nid, const char *name)
+static int check_provider(EVP_PKEY_CTX *ctx, const char *expected_provider)
 {
-    int            ret = 0;
-    size_t         siglen;
-    unsigned char  sigbuf[1024];
-    EVP_PKEY_CTX  *ctx = NULL;
-    EVP_PKEY      *ec_pkey = NULL;
-    EVP_PKEY      *peer_pkey = NULL;
-    size_t         keylen1, keylen2;
-    unsigned char  keybuf1[512], keybuf2[512];
-    EVP_MD_CTX     *md_ctx = NULL;
-    unsigned char  digest[32];
     const OSSL_PROVIDER *provider;
     const char *provname;
 
-    memset(digest, 0, sizeof(digest));
+    if (expected_provider == NULL)
+        expected_provider = "default";
 
-    /* Keygen with IBMCA provider */
-    ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", "?provider=ibmca");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_name failed\n");
-        goto out;
+    provider = EVP_PKEY_CTX_get0_provider(ctx);
+    if (provider == NULL) {
+        fprintf(stderr, "Context is not a provider-context\n");
+        return 0;
+    }
+
+    provname = OSSL_PROVIDER_get0_name(provider);
+    if (strcmp(provname, expected_provider) != 0) {
+        fprintf(stderr, "Context is not using the %s provider, but '%s'\n",
+                expected_provider, provname);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int generate_key(const char* provider, int nid, const char *curvename,
+                        const OSSL_PARAM *params, EVP_PKEY *template,
+                        EVP_PKEY **ec_pkey)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    if (template != NULL) {
+        ctx = EVP_PKEY_CTX_new_from_pkey(NULL, template, props);
+        if (ctx == NULL) {
+            fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+            goto out;
+        }
+    } else {
+        ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", props);
+        if (ctx == NULL) {
+            fprintf(stderr, "EVP_PKEY_CTX_new_from_name failed\n");
+            goto out;
+        }
     }
 
     if (EVP_PKEY_keygen_init(ctx) <= 0) {
@@ -70,45 +95,61 @@ int check_eckey(int nid, const char *name)
         goto out;
     }
 
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
+    if (!check_provider(ctx, provider))
         goto out;
-    }
 
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid) <= 0) {
-        if (ERR_GET_REASON(ERR_peek_last_error()) == 7) {
-            /* curve not supported => test passed */
-            fprintf(stderr, "Curve %s not supported by OpenSSL\n", name);
-            ret = 1;
-        } else {
-            fprintf(stderr, "EVP_PKEY_CTX_set_ec_paramgen_curve_nid failed\n");
+    if (template == NULL) {
+        if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid) <= 0) {
+            if (ERR_GET_REASON(ERR_peek_last_error()) == 7) {
+                /* curve not supported => test passed */
+                fprintf(stderr, "Curve %s not supported by OpenSSL\n", curvename);
+                ok = 1;
+            } else {
+                fprintf(stderr, "EVP_PKEY_CTX_set_ec_paramgen_curve_nid failed\n");
+            }
+            goto out;
         }
-        goto out;
     }
 
-    if (EVP_PKEY_keygen(ctx, &ec_pkey) <= 0) {
+    if (params != NULL) {
+        if (EVP_PKEY_CTX_set_params(ctx, params) != 1) {
+            fprintf(stderr, "EVP_PKEY_CTX_set_params failed\n");
+            goto out;
+        }
+    }
+
+    if (EVP_PKEY_keygen(ctx, ec_pkey) <= 0) {
         if (ERR_GET_REASON(ERR_peek_last_error()) == 7) {
             /* curve not supported => test passed */
-            fprintf(stderr, "Curve %s not supported by OpenSSL\n", name);
-            ret = 1;
+            fprintf(stderr, "Curve %s not supported by OpenSSL\n", curvename);
+            ok = 1;
         } else {
             fprintf(stderr, "EVP_PKEY_keygen failed\n");
         }
         goto out;
     }
 
-    EVP_PKEY_CTX_free(ctx);
+    ok = 1;
 
-    /* Sign with IBMCA provider */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "?provider=ibmca");
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+
+    return ok;
+}
+
+static int sign_single(const char* provider, EVP_PKEY *ec_pkey,
+                       const unsigned char *tbs, size_t tbs_len,
+                       unsigned char *sig, size_t *sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, props);
     if (ctx == NULL) {
         fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
         goto out;
@@ -119,669 +160,380 @@ int check_eckey(int nid, const char *name)
         goto out;
     }
 
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
+    if (!check_provider(ctx, provider))
         goto out;
-    }
 
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    siglen = sizeof(sigbuf);
-    if (EVP_PKEY_sign(ctx, sigbuf, &siglen, digest, sizeof(digest)) <= 0) {
+    if (EVP_PKEY_sign(ctx, sig, sig_len, tbs, tbs_len) <= 0) {
         fprintf(stderr, "EVP_PKEY_sign failed\n");
         goto out;
     }
 
-    EVP_PKEY_CTX_free(ctx);
+    ok = 1;
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+
+    return ok;
+}
+
+static int verify_single(const char* provider, const char *curvename,
+                         EVP_PKEY *ec_pkey, const unsigned char *tbs,
+                         size_t tbs_len, const unsigned char *sig,
+                         size_t sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_verify_init(ctx) <= 0) {
+        fprintf(stderr, "EVP_PKEY_verify_init failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    ok = EVP_PKEY_verify(ctx, sig, sig_len, tbs, tbs_len);
+    if (ok == -1) {
+        /* error */
+        fprintf(stderr, "Failed to verify signature with %s (%s provider)\n",
+                curvename, provider != NULL ? provider : "default");
+        ok = 0;
+        goto out;
+    } else if (ok == 0) {
+        /* incorrect signature */
+        fprintf(stderr, "Signature incorrect with %s (%s provider)\n",
+                curvename, provider != NULL ? provider : "default");
+        goto out;
+    } else {
+        /* signature ok */
+        printf("Signature correct with %s (%s provider)\n", curvename,
+                provider != NULL ? provider : "default");
+        ok = 1;
+    }
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+
+    return ok;
+}
+
+static int sign_digest(const char* provider, EVP_PKEY *ec_pkey,
+                       const char *md_name, const OSSL_PARAM *params,
+                       const unsigned char *tbs, size_t tbs_len,
+                       unsigned char *sig, size_t *sig_len)
+{
+    char props[200];
+    EVP_MD_CTX *md_ctx = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    md_ctx = EVP_MD_CTX_new();
+    if (md_ctx == NULL) {
+        fprintf(stderr, "EVP_MD_CTX_new failed\n");
+        goto out;
+    }
+
+    if (EVP_DigestSignInit_ex(md_ctx, &ctx, md_name, NULL,
+                              props, ec_pkey, NULL) == 0) {
+        fprintf(stderr, "EVP_DigestSignInit_ex failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (params != NULL) {
+        if (EVP_PKEY_CTX_set_params(ctx, params) == 0) {
+            fprintf(stderr, "EVP_PKEY_CTX_set_params failed\n");
+            goto out;
+        }
+    }
+
+    if (EVP_DigestSignUpdate(md_ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_DigestSignUpdate (1) failed\n");
+        goto out;
+    }
+
+    if (EVP_DigestSignUpdate(md_ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_DigestSignUpdate (2) failed\n");
+        goto out;
+    }
+
+    if (EVP_DigestSignFinal(md_ctx, sig, sig_len) <= 0) {
+        fprintf(stderr, "EVP_DigestSignFinal failed\n");
+        goto out;
+    }
+
+    ok = 1;
+
+out:
+    if (md_ctx != NULL)
+        EVP_MD_CTX_free(md_ctx);
+
+    return ok;
+}
+
+static int verify_digest(const char* provider, const char *curvename,
+                         EVP_PKEY *ec_pkey, const char *md_name,
+                         const unsigned char *tbs, size_t tbs_len,
+                         unsigned char *sig, size_t sig_len)
+{
+    char props[200];
+    EVP_MD_CTX *md_ctx = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    md_ctx = EVP_MD_CTX_new();
+    if (md_ctx == NULL) {
+        fprintf(stderr, "EVP_MD_CTX_new failed\n");
+        goto out;
+    }
+
+    if (EVP_DigestVerifyInit_ex(md_ctx, &ctx, md_name, NULL,
+                                props, ec_pkey, NULL) == 0) {
+        fprintf(stderr, "EVP_DigestVerifyInit_ex failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (EVP_DigestVerifyUpdate(md_ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_DigestVerifyUpdate (1) failed\n");
+        goto out;
+    }
+
+    if (EVP_DigestVerifyUpdate(md_ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_DigestVerifyUpdate (2) failed\n");
+        goto out;
+    }
+
+    ok = EVP_DigestVerifyFinal(md_ctx, sig, sig_len);
+    if (ok == -1) {
+        /* error */
+        fprintf(stderr, "Failed to digest-verify signature with %s (%s provider)\n",
+                curvename, provider != NULL ? provider : "default");
+        ok = 0;
+        goto out;
+    } else if (ok == 0) {
+        /* incorrect signature */
+        fprintf(stderr, "Digest-Signature incorrect with %s (%s provider)\n",
+                curvename, provider != NULL ? provider : "default");
+        goto out;
+    } else {
+        /* signature ok */
+        printf("Digest-Signature correct with %s (%s provider)\n", curvename,
+                provider != NULL ? provider : "default");
+        ok = 1;
+    }
+
+out:
+    if (md_ctx != NULL)
+        EVP_MD_CTX_free(md_ctx);
+
+    return ok;
+}
+
+static int derive_key(const char* provider, EVP_PKEY *ec_pkey,
+                      EVP_PKEY *peer_pkey, int kdf, const char *kdf_md,
+                      size_t kdf_outlen, unsigned char *derived_key,
+                      size_t *derived_key_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_derive_init(ctx) <= 0) {
+        fprintf(stderr, "EVP_PKEY_derive_init failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (kdf != 0 && kdf_md != NULL && kdf_outlen != 0) {
+        if (EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, kdf) != 1) {
+            fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_type failed\n");
+            goto out;
+        }
+
+        if (EVP_PKEY_CTX_set_ecdh_kdf_md(ctx,
+                                         EVP_get_digestbyname(kdf_md)) != 1) {
+            fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_md failed\n");
+            goto out;
+        }
+
+        if (EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, kdf_outlen) != 1) {
+            fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_outlen failed\n");
+            goto out;
+        }
+    }
+
+    if (EVP_PKEY_derive_set_peer_ex(ctx, peer_pkey, 1) != 1) {
+        fprintf(stderr, "EVP_PKEY_derive_set_peer_ex failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_derive(ctx, derived_key, derived_key_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_derive failed\n");
+        goto out;
+    }
+
+    ok = 1;
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+
+    return ok;
+}
+
+static int check_eckey(int nid, const char *curvename)
+{
+    int            ok = 0;
+    size_t         siglen;
+    unsigned char  sigbuf[1024];
+    EVP_PKEY      *ec_pkey = NULL;
+    EVP_PKEY      *peer_pkey = NULL;
+    size_t         keylen1, keylen2;
+    unsigned char  keybuf1[512], keybuf2[512];
+    unsigned char  digest[32];
+
+    memset(digest, 0, sizeof(digest));
+
+    /* Keygen with IBMCA provider */
+    if (!generate_key("ibmca", nid, curvename, NULL, NULL, &ec_pkey))
+        goto out;
+    if (ec_pkey == NULL) {
+        ok = 1; /* Curve not supported, skip */
+        goto out;
+    }
+
+    /* Sign with IBMCA provider */
+    siglen = sizeof(sigbuf);
+    if (!sign_single("ibmca", ec_pkey, digest, sizeof(digest),
+                     sigbuf, &siglen))
+        goto out;
 
     /* Verify with default provider */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "provider=default");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+    if (!verify_single(NULL, curvename, ec_pkey,
+                       digest, sizeof(digest), sigbuf, siglen))
         goto out;
-    }
-
-    if (EVP_PKEY_verify_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_verify_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "default") != 0) {
-        fprintf(stderr, "Context is not using the default provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    ret = EVP_PKEY_verify(ctx, sigbuf, siglen, digest, sizeof(digest));
-    if (ret == -1) {
-        /* error */
-        fprintf(stderr, "Failed to verify signature with %s (default provider)\n", name);
-        goto out;
-    } else if (ret == 0) {
-        /* incorrect signature */
-        fprintf(stderr, "Signature incorrect with %s (default provider)\n", name);
-        goto out;
-    } else {
-        /* signature ok */
-        printf("Signature correct with %s (default provider)\n", name);
-        ret = 0;
-    }
-
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
 
     /* Verify with IBMCA provider */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "?provider=ibmca");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+    if (!verify_single("ibmca", curvename, ec_pkey,
+                       digest, sizeof(digest), sigbuf, siglen))
         goto out;
-    }
 
-    if (EVP_PKEY_verify_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_verify_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    ret = EVP_PKEY_verify(ctx, sigbuf, siglen, digest, sizeof(digest));
-    if (ret == -1) {
-        /* error */
-        fprintf(stderr, "Failed to verify signature with %s (ibmca provider)\n", name);
-        goto out;
-    } else if (ret == 0) {
-        /* incorrect signature */
-        fprintf(stderr, "Signature incorrect with %s (ibmca provider)\n", name);
-        goto out;
-    } else {
-        /* signature ok */
-        printf("Signature correct with %s (ibmca provider)\n", name);
-        ret = 0;
-    }
-
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
 
     /* Digest-Sign with IBMCA provider */
-    md_ctx = EVP_MD_CTX_new();
-    if (md_ctx == NULL) {
-        fprintf(stderr, "EVP_MD_CTX_new failed\n");
-        goto out;
-    }
-
-    if (EVP_DigestSignInit_ex(md_ctx, &ctx, "SHA256", NULL,
-                               "?provider=ibmca", ec_pkey, NULL) == 0) {
-        fprintf(stderr, "EVP_DigestSignInit_ex failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_DigestSignUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestSignUpdate (1) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestSignUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestSignUpdate (2) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
     siglen = sizeof(sigbuf);
-    if (EVP_DigestSignFinal(md_ctx, sigbuf, &siglen) <= 0) {
-        fprintf(stderr, "EVP_DigestSignFinal failed\n");
-        ctx = NULL;
+    if (!sign_digest("ibmca", ec_pkey, "SHA256", NULL,
+                     digest, sizeof(digest), sigbuf, &siglen))
         goto out;
-    }
-
-    EVP_MD_CTX_free(md_ctx);
-    ctx = NULL;
 
     /* Digest-Verify with default provider */
-    md_ctx = EVP_MD_CTX_new();
-    if (md_ctx == NULL) {
-        fprintf(stderr, "EVP_MD_CTX_new failed\n");
+    if (!verify_digest(NULL, curvename, ec_pkey, "SHA256",
+                       digest, sizeof(digest), sigbuf, siglen))
         goto out;
-    }
-
-    if (EVP_DigestVerifyInit_ex(md_ctx, &ctx, "SHA256", NULL,
-                                "provider=default", ec_pkey, NULL) == 0) {
-        fprintf(stderr, "EVP_DigestVerifyInit_ex failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (1) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (2) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    ret = EVP_DigestVerifyFinal(md_ctx, sigbuf, siglen);
-    if (ret == -1) {
-        /* error */
-        fprintf(stderr, "Failed to digest-verify signature with %s (default provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else if (ret == 0) {
-        /* incorrect signature */
-        fprintf(stderr, "Digest-Signature incorrect with %s (default provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else {
-        /* signature ok */
-        printf("Digest-Signature correct with %s (default provider)\n", name);
-        ret = 0;
-    }
-
-    EVP_MD_CTX_free(md_ctx);
-    ctx = NULL;
 
     /* Digest-Verify with IBMCA provider */
-    md_ctx = EVP_MD_CTX_new();
-    if (md_ctx == NULL) {
-        fprintf(stderr, "EVP_MD_CTX_new failed\n");
+    if (!verify_digest("ibmca", curvename, ec_pkey, "SHA256",
+                       digest, sizeof(digest), sigbuf, siglen))
         goto out;
-    }
-
-    if (EVP_DigestVerifyInit_ex(md_ctx, &ctx, "SHA256", NULL,
-                                "?provider=ibmca", ec_pkey, NULL) == 0) {
-        fprintf(stderr, "EVP_DigestVerifyInit_ex failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (1) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (2) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    ret = EVP_DigestVerifyFinal(md_ctx, sigbuf, siglen);
-    if (ret == -1) {
-        /* error */
-        fprintf(stderr, "Failed to digest-verify signature with %s (IBMCA provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else if (ret == 0) {
-        /* incorrect signature */
-        fprintf(stderr, "Digest-Signature incorrect with %s (IBMCA provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else {
-        /* signature ok */
-        printf("Digest-Signature correct with %s (IBMCA provider)\n", name);
-        ret = 0;
-    }
-
-    EVP_MD_CTX_free(md_ctx);
-    ctx = NULL;
 
     /* Digest-Sign with default provider */
-    md_ctx = EVP_MD_CTX_new();
-    if (md_ctx == NULL) {
-        fprintf(stderr, "EVP_MD_CTX_new failed\n");
-        goto out;
-    }
-
-    if (EVP_DigestSignInit_ex(md_ctx, &ctx, "SHA256", NULL,
-                               "provider=default", ec_pkey, NULL) == 0) {
-        fprintf(stderr, "EVP_DigestSignInit_ex failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "default") != 0) {
-        fprintf(stderr, "Context is not using the default provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_DigestSignUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestSignUpdate (1) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestSignUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestSignUpdate (2) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
     siglen = sizeof(sigbuf);
-    if (EVP_DigestSignFinal(md_ctx, sigbuf, &siglen) <= 0) {
-        fprintf(stderr, "EVP_DigestSignFinal failed\n");
-        ctx = NULL;
+    if (!sign_digest(NULL, ec_pkey, "SHA256", NULL,
+                     digest, sizeof(digest), sigbuf, &siglen))
         goto out;
-    }
-
-    EVP_MD_CTX_free(md_ctx);
-    ctx = NULL;
 
     /* Digest-Verify with default provider */
-    md_ctx = EVP_MD_CTX_new();
-    if (md_ctx == NULL) {
-        fprintf(stderr, "EVP_MD_CTX_new failed\n");
+    if (!verify_digest(NULL, curvename, ec_pkey, "SHA256",
+                       digest, sizeof(digest), sigbuf, siglen))
         goto out;
-    }
-
-    if (EVP_DigestVerifyInit_ex(md_ctx, &ctx, "SHA256", NULL,
-                                "provider=default", ec_pkey, NULL) == 0) {
-        fprintf(stderr, "EVP_DigestVerifyInit_ex failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (1) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (2) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    ret = EVP_DigestVerifyFinal(md_ctx, sigbuf, siglen);
-    if (ret == -1) {
-        /* error */
-        fprintf(stderr, "Failed to digest-verify signature with %s (default provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else if (ret == 0) {
-        /* incorrect signature */
-        fprintf(stderr, "Digest-Signature incorrect with %s (default provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else {
-        /* signature ok */
-        printf("Digest-Signature correct with %s (default provider)\n", name);
-        ret = 0;
-    }
-
-    EVP_MD_CTX_free(md_ctx);
-    ctx = NULL;
 
     /* Digest-Verify with IBMCA provider */
-    md_ctx = EVP_MD_CTX_new();
-    if (md_ctx == NULL) {
-        fprintf(stderr, "EVP_MD_CTX_new failed\n");
+    if (!verify_digest("ibmca", curvename, ec_pkey, "SHA256",
+                       digest, sizeof(digest), sigbuf, siglen))
         goto out;
-    }
-
-    if (EVP_DigestVerifyInit_ex(md_ctx, &ctx, "SHA256", NULL,
-                                "?provider=ibmca", ec_pkey, NULL) == 0) {
-        fprintf(stderr, "EVP_DigestVerifyInit_ex failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (1) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    if (EVP_DigestVerifyUpdate(md_ctx, digest, sizeof(digest)) <= 0) {
-        fprintf(stderr, "EVP_DigestVerifyUpdate (2) failed\n");
-        ctx = NULL;
-        goto out;
-    }
-
-    ret = EVP_DigestVerifyFinal(md_ctx, sigbuf, siglen);
-    if (ret == -1) {
-        /* error */
-        fprintf(stderr, "Failed to digest-verify signature with %s (IBMCA provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else if (ret == 0) {
-        /* incorrect signature */
-        fprintf(stderr, "Digest-Signature incorrect with %s (IBMCA provider)\n", name);
-        ctx = NULL;
-        goto out;
-    } else {
-        /* signature ok */
-        printf("Digest-Signature correct with %s (IBMCA provider)\n", name);
-        ret  =0;
-    }
-
-    ctx = NULL;
 
     /* Keygen with IBMCA provider (using ec_pkey as template) */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "?provider=ibmca");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+    if (!generate_key("ibmca", nid, curvename, NULL, ec_pkey, &peer_pkey))
         goto out;
-    }
-
-    if (EVP_PKEY_keygen_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_keygen_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_PKEY_keygen(ctx, &peer_pkey) <= 0) {
-        if (ERR_GET_REASON(ERR_peek_last_error()) == 7) {
-            /* curve not supported => test passed */
-            fprintf(stderr, "Curve %s not supported by OpenSSL\n", name);
-            ret = 1;
-        } else {
-            fprintf(stderr, "EVP_PKEY_keygen failed\n");
-        }
-        goto out;
-    }
-
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
 
     /* Derive with IBMCA provider (no KDF) */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "?provider=ibmca");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_set_peer_ex(ctx, peer_pkey, 1) != 1) {
-        fprintf(stderr, "EVP_PKEY_derive_set_peer_ex failed\n");
-        goto out;
-    }
-
     keylen1 = sizeof(keybuf1);
-    if (EVP_PKEY_derive(ctx, keybuf1, &keylen1) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive failed\n");
+    if (!derive_key("ibmca", ec_pkey, peer_pkey, 0, NULL, 0, keybuf1, &keylen1))
         goto out;
-    }
-
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
 
     /* Derive with default provider (no KDF) */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "provider=default");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "default") != 0) {
-        fprintf(stderr, "Context is not using the default provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_set_peer_ex(ctx, peer_pkey, 1) != 1) {
-        fprintf(stderr, "EVP_PKEY_derive_set_peer_ex failed\n");
-        goto out;
-    }
-
     keylen2 = sizeof(keybuf2);
-    if (EVP_PKEY_derive(ctx, keybuf2, &keylen2) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive failed\n");
+    if (!derive_key(NULL, ec_pkey, peer_pkey, 0, NULL, 0, keybuf2, &keylen2))
         goto out;
-    }
 
     if (keylen1 != keylen2 || memcmp(keybuf1, keybuf2, keylen1) != 0) {
         fprintf(stderr, "Derived keys are not equal\n");
         goto out;
     }
-
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
 
     /* Derive with IBMCA provider (X9_63 KDF) */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "?provider=ibmca");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "ibmca") != 0) {
-        fprintf(stderr, "Context is not using the IBMCA provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, EVP_PKEY_ECDH_KDF_X9_63) != 1) {
-        fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_type failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, EVP_get_digestbyname("SHA256")) != 1) {
-        fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_md failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, sizeof(keybuf1)) != 1) {
-        fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_outlen failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_set_peer_ex(ctx, peer_pkey, 1) != 1) {
-        fprintf(stderr, "EVP_PKEY_derive_set_peer_ex failed\n");
-        goto out;
-    }
-
     keylen1 = sizeof(keybuf1);
-    if (EVP_PKEY_derive(ctx, keybuf1, &keylen1) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive failed\n");
+    if (!derive_key("ibmca", ec_pkey, peer_pkey,
+                    EVP_PKEY_ECDH_KDF_X9_63, "SHA256", keylen1,
+                    keybuf1, &keylen1))
         goto out;
-    }
-
-    EVP_PKEY_CTX_free(ctx);
-    ctx = NULL;
 
     /* Derive with default provider (X9_63 KDF) */
-    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, ec_pkey, "provider=default");
-    if (ctx == NULL) {
-        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_init(ctx) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive_init failed\n");
-        goto out;
-    }
-
-    provider = EVP_PKEY_CTX_get0_provider(ctx);
-    if (provider == NULL) {
-        fprintf(stderr, "Context is not a provider-context\n");
-        goto out;
-    }
-
-    provname = OSSL_PROVIDER_get0_name(provider);
-    if (strcmp(provname, "default") != 0) {
-        fprintf(stderr, "Context is not using the default provider, but '%s'\n",
-               provname);
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, EVP_PKEY_ECDH_KDF_X9_63) != 1) {
-        fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_type failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, EVP_get_digestbyname("SHA256")) != 1) {
-        fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_md failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, sizeof(keybuf2)) != 1) {
-        fprintf(stderr, "EVP_PKEY_CTX_set_ecdh_kdf_outlen failed\n");
-        goto out;
-    }
-
-    if (EVP_PKEY_derive_set_peer_ex(ctx, peer_pkey, 1) != 1) {
-        fprintf(stderr, "EVP_PKEY_derive_set_peer_ex failed\n");
-        goto out;
-    }
-
     keylen2 = sizeof(keybuf2);
-    if (EVP_PKEY_derive(ctx, keybuf2, &keylen2) <= 0) {
-        fprintf(stderr, "EVP_PKEY_derive failed\n");
+    if (!derive_key(NULL, ec_pkey, peer_pkey,
+                    EVP_PKEY_ECDH_KDF_X9_63, "SHA256", keylen2,
+                    keybuf2, &keylen2))
         goto out;
-    }
 
     if (keylen1 != keylen2 || memcmp(keybuf1, keybuf2, keylen1) != 0) {
         fprintf(stderr, "Derived keys are not equal\n");
         goto out;
     }
 
-    ret = 1;
+    ok = 1;
 
  out:
     if (peer_pkey)
        EVP_PKEY_free(peer_pkey);
     if (ec_pkey)
        EVP_PKEY_free(ec_pkey);
-    if (ctx)
-       EVP_PKEY_CTX_free(ctx);
-    if (md_ctx)
-        EVP_MD_CTX_free(md_ctx);
 
     ERR_print_errors_fp(stderr);
 
-    return ret;
+    return ok;
 }
 
 static const unsigned int required_ica_mechs[] = { EC_DH, EC_DSA_SIGN,
@@ -792,7 +544,7 @@ static const unsigned int required_ica_mechs_len =
 typedef unsigned int (*ica_get_functionlist_t)(libica_func_list_element *,
                                                unsigned int *);
 
-int check_libica()
+static int check_libica()
 {
     unsigned int mech_len, i, k, found = 0;
     libica_func_list_element *mech_list = NULL;

--- a/test/provider/rsakey.c
+++ b/test/provider/rsakey.c
@@ -396,6 +396,364 @@ out:
     return ok;
 }
 
+#ifdef EVP_PKEY_OP_SIGNMSG
+static int sign_message(const char* provider, EVP_PKEY *rsa_pkey,
+                        const char *alg_name, const unsigned char *tbs,
+                        size_t tbs_len, unsigned char *sig, size_t *sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_SIGNATURE *alg = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    alg = EVP_SIGNATURE_fetch(NULL, alg_name, props);
+    if (alg == NULL) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch for %s failed\n", alg_name);
+        goto out;
+    }
+
+    if (EVP_PKEY_sign_message_init(ctx, alg, NULL) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign_message_init failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (EVP_PKEY_sign_message_update(ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign_message_update (1) failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_sign_message_update(ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign_message_update (2) failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_sign_message_final(ctx, sig, sig_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign_message_final failed\n");
+        goto out;
+    }
+
+    ok = 1;
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+    if (alg != NULL)
+        EVP_SIGNATURE_free(alg);
+
+    return ok;
+}
+
+static int verify_message(const char* provider, const char *algo,
+                          EVP_PKEY *rsa_pkey, const char *alg_name,
+                          const unsigned char *tbs, size_t tbs_len,
+                          unsigned char *sig, size_t sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_SIGNATURE *alg = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    alg = EVP_SIGNATURE_fetch(NULL, alg_name, props);
+    if (alg == NULL) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch for %s failed\n", alg_name);
+        goto out;
+    }
+
+    if (EVP_PKEY_verify_message_init(ctx, alg, NULL) <= 0) {
+        fprintf(stderr, "EVP_PKEY_verify_message_init failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (EVP_PKEY_CTX_set_signature(ctx, sig, sig_len) != 1) {
+        fprintf(stderr, "EVP_PKEY_CTX_set_signature failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_verify_message_update(ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_verify_message_update (1) failed\n");
+        goto out;
+    }
+
+    if (EVP_PKEY_verify_message_update(ctx, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_verify_message_update (2) failed\n");
+        goto out;
+    }
+
+    ok = EVP_PKEY_verify_message_final(ctx);
+    if (ok == -1) {
+        /* error */
+        fprintf(stderr, "Failed to verify-message signature with %s (%s provider)\n",
+                algo, provider != NULL ? provider : "default");
+        ok = 0;
+        goto out;
+    } else if (ok == 0) {
+        /* incorrect signature */
+        fprintf(stderr, "Message-Signature incorrect with %s (%s provider)\n",
+                algo, provider != NULL ? provider : "default");
+        goto out;
+    } else {
+        /* signature ok */
+        printf("Message-Signature correct with %s (%s provider)\n", algo,
+                provider != NULL ? provider : "default");
+        ok = 1;
+    }
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+    if (alg != NULL)
+        EVP_SIGNATURE_free(alg);
+
+    return ok;
+}
+
+static int sign_message_single(const char* provider, EVP_PKEY *rsa_pkey,
+                               const char *alg_name, const unsigned char *tbs,
+                               size_t tbs_len, unsigned char *sig,
+                               size_t *sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_SIGNATURE *alg = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    alg = EVP_SIGNATURE_fetch(NULL, alg_name, props);
+    if (alg == NULL) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch for %s failed\n", alg_name);
+        goto out;
+    }
+
+    if (EVP_PKEY_sign_message_init(ctx, alg, NULL) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign_message_init failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (EVP_PKEY_sign(ctx, sig, sig_len, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign failed\n");
+        goto out;
+    }
+
+    ok = 1;
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+    if (alg != NULL)
+        EVP_SIGNATURE_free(alg);
+
+    return ok;
+}
+
+static int verify_message_single(const char* provider, const char *algo,
+                                 EVP_PKEY *rsa_pkey, const char *alg_name,
+                                 const unsigned char *tbs, size_t tbs_len,
+                                 unsigned char *sig, size_t sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_SIGNATURE *alg = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    alg = EVP_SIGNATURE_fetch(NULL, alg_name, props);
+    if (alg == NULL) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch for %s failed\n", alg_name);
+        goto out;
+    }
+
+    if (EVP_PKEY_verify_message_init(ctx, alg, NULL) <= 0) {
+        fprintf(stderr, "EVP_PKEY_verify_message_init failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+
+    ok = EVP_PKEY_verify(ctx, sig, sig_len, tbs, tbs_len);
+    if (ok == -1) {
+        /* error */
+        fprintf(stderr, "Failed to verify-message-single signature with %s (%s provider)\n",
+                algo, provider != NULL ? provider : "default");
+        ok = 0;
+        goto out;
+    } else if (ok == 0) {
+        /* incorrect signature */
+        fprintf(stderr, "Message-Signature single incorrect with %s (%s provider)\n",
+                algo, provider != NULL ? provider : "default");
+        goto out;
+    } else {
+        /* signature ok */
+        printf("Message-Signature single correct with %s (%s provider)\n", algo,
+                provider != NULL ? provider : "default");
+        ok = 1;
+    }
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+    if (alg != NULL)
+        EVP_SIGNATURE_free(alg);
+
+    return ok;
+}
+
+static int sign_message_prehashed(const char* provider, EVP_PKEY *rsa_pkey,
+                                  const char *alg_name,
+                                  const unsigned char *tbs, size_t tbs_len,
+                                  unsigned char *sig, size_t *sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_SIGNATURE *alg = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    alg = EVP_SIGNATURE_fetch(NULL, alg_name, props);
+    if (alg == NULL) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch for %s failed\n", alg_name);
+        goto out;
+    }
+
+    if (EVP_PKEY_sign_init_ex2(ctx, alg, NULL) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign_init_ex2 failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+    if (EVP_PKEY_sign(ctx, sig, sig_len, tbs, tbs_len) <= 0) {
+        fprintf(stderr, "EVP_PKEY_sign failed\n");
+        goto out;
+    }
+
+    ok = 1;
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+    if (alg != NULL)
+        EVP_SIGNATURE_free(alg);
+
+    return ok;
+}
+
+static int verify_message_prehashed(const char* provider, const char *algo,
+                                    EVP_PKEY *rsa_pkey, const char *alg_name,
+                                    const unsigned char *tbs, size_t tbs_len,
+                                    unsigned char *sig, size_t sig_len)
+{
+    char props[200];
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_SIGNATURE *alg = NULL;
+    int ok = 0;
+
+    sprintf(props, "%sprovider=%s", provider != NULL ? "?" : "",
+            provider != NULL ? provider : "default");
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa_pkey, props);
+    if (ctx == NULL) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed\n");
+        goto out;
+    }
+
+    alg = EVP_SIGNATURE_fetch(NULL, alg_name, props);
+    if (alg == NULL) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch for %s failed\n", alg_name);
+        goto out;
+    }
+
+    if (EVP_PKEY_verify_init_ex2(ctx, alg, NULL) <= 0) {
+        fprintf(stderr, "EVP_PKEY_verify_init_ex2 failed\n");
+        goto out;
+    }
+
+    if (!check_provider(ctx, provider))
+        goto out;
+
+
+    ok = EVP_PKEY_verify(ctx, sig, sig_len, tbs, tbs_len);
+    if (ok == -1) {
+        /* error */
+        fprintf(stderr, "Failed to verify-message-prehashed signature with %s (%s provider)\n",
+                algo, provider != NULL ? provider : "default");
+        ok = 0;
+        goto out;
+    } else if (ok == 0) {
+        /* incorrect signature */
+        fprintf(stderr, "Message-Signature prehashed incorrect with %s (%s provider)\n",
+                algo, provider != NULL ? provider : "default");
+        goto out;
+    } else {
+        /* signature ok */
+        printf("Message-Signature prehashed correct with %s (%s provider)\n", algo,
+                provider != NULL ? provider : "default");
+        ok = 1;
+    }
+
+out:
+    if (ctx != NULL)
+        EVP_PKEY_CTX_free(ctx);
+    if (alg != NULL)
+        EVP_SIGNATURE_free(alg);
+
+    return ok;
+}
+#endif
+
 static int check_rsakey(int bits, const char *algo, const char *name)
 {
     int            ok = 0;
@@ -476,6 +834,61 @@ static int check_rsakey(int bits, const char *algo, const char *name)
                        pss_padding, pss_mgf1_md, pss_saltlen,
                        digest, sizeof(digest), sigbuf, siglen))
         goto out;
+
+#ifdef EVP_PKEY_OP_SIGNMSG
+    if (strcmp(algo, "RSA-PSS") == 0)
+        goto skip;
+
+    /* SignMessage with IBMCA provider */
+    siglen = sizeof(sigbuf);
+    if (!sign_message("ibmca", rsa_pkey, "RSA-SHA256",
+                      digest, sizeof(digest), sigbuf, &siglen))
+        goto out;
+
+    /* VerifyMessage with default provider */
+    if (!verify_message(NULL, name, rsa_pkey, "RSA-SHA256",
+                        digest, sizeof(digest), sigbuf, siglen))
+        goto out;
+
+    /* VerifyMessage with IBMCA provider */
+    if (!verify_message("ibmca", name, rsa_pkey, "RSA-SHA256",
+                        digest, sizeof(digest), sigbuf, siglen))
+        goto out;
+
+    /* SignMessage one-shot with IBMCA provider */
+    siglen = sizeof(sigbuf);
+    if (!sign_message_single("ibmca", rsa_pkey, "RSA-SHA256",
+                             digest, sizeof(digest), sigbuf, &siglen))
+        goto out;
+
+    /* VerifyMessage one-shot with default provider */
+    if (!verify_message_single(NULL, name, rsa_pkey, "RSA-SHA256",
+                               digest, sizeof(digest), sigbuf, siglen))
+        goto out;
+
+    /* VerifyMessage one-shot with IBMCA provider */
+    if (!verify_message_single("ibmca", name, rsa_pkey, "RSA-SHA256",
+                               digest, sizeof(digest), sigbuf, siglen))
+        goto out;
+
+    /* Sign pre-hashed message with IBMCA provider */
+    siglen = sizeof(sigbuf);
+    if (!sign_message_prehashed("ibmca", rsa_pkey, "RSA-SHA256",
+                                digest, sizeof(digest), sigbuf, &siglen))
+        goto out;
+
+    /* Verify pre-hashed message with default provider */
+    if (!verify_message_prehashed(NULL, name, rsa_pkey, "RSA-SHA256",
+                                  digest, sizeof(digest), sigbuf, siglen))
+        goto out;
+
+    /* Verify pre-hashed message with IBMCA provider */
+    if (!verify_message_prehashed("ibmca", name, rsa_pkey, "RSA-SHA256",
+                                  digest, sizeof(digest), sigbuf, siglen))
+        goto out;
+
+skip:
+#endif
 
     ok = 1;
 

--- a/test/provider/threadtest.c
+++ b/test/provider/threadtest.c
@@ -33,8 +33,7 @@
 /* This is just a random number of threads to stimulate provider configuration. */
 #define DEFAULT_MAX_THREADS 20
 
-
-void setup(void)
+static void setup(void)
 {
     OPENSSL_load_builtin_modules();
 


### PR DESCRIPTION
- Support deterministic EC signatures (nonzero OSSL_SIGNATURE_PARAM_NONCE_TYPE) via fallback provider.
- Support EC DHKEM (SSL_PKEY_PARAM_DHKEM_IKM) via fallback provider.
- Support SignMessage and VerifyMessage API (since OpenSSL 3.4) for ECDSA and RSA for composite hash-then-sign algorithms.
- Support import RSA keys from just P and Q (OSSL_PKEY_PARAM_RSA_DERIVE_FROM_PQ, since OpenSSL 3.3).
- Misc updates and fixes


Closes: https://github.com/opencryptoki/openssl-ibmca/issues/119
Closes: https://github.com/opencryptoki/openssl-ibmca/issues/114