### PR TITLE
TRAVIS: Disable the build of the IBMCA engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
          os: linux
          arch: s390x
          compiler: gcc
-         env: CONFIG_OPTS="--enable-engine --enable-provider"
+         env: CONFIG_OPTS="--disable-engine --enable-provider"
  
 before_script:
     - git clone https://github.com/openssl/openssl.git


### PR DESCRIPTION
OpenSSL 4.0.0 removed support for engines, so don't try to build the IBMCA engine because this will fail.